### PR TITLE
Validation reward amount can be zero if the validator is review protocol

### DIFF
--- a/src/ThriveWorkerUnit.sol
+++ b/src/ThriveWorkerUnit.sol
@@ -91,10 +91,6 @@ contract ThriveWorkerUnit is ReentrancyGuard {
             "ThriveProtocol: deadline must be in the future"
         );
         require(_rewardAmount > 0, "ThriveProtocol: invalid reward amount!");
-        require(
-            _validationRewardAmount > 0,
-            "ThriveProtocol: invalid validation reward amount!"
-        );
 
         moderator = _moderator;
         rewardToken = _rewardToken;

--- a/test/ThriveWorkerUnit.t.sol
+++ b/test/ThriveWorkerUnit.t.sol
@@ -81,20 +81,6 @@ contract ThriveWorkerUnitTest is Test {
             address(0),
             badgeQuery
         );
-
-        vm.expectRevert("ThriveProtocol: invalid validation reward amount!");
-        new ThriveWorkerUnit(
-            moderator,
-            address(mockToken),
-            10,
-            100 ether,
-            0,
-            block.timestamp + 1 days,
-            2,
-            validators,
-            address(0),
-            badgeQuery
-        );
     }
 
     function testInitializeRequirements() public {


### PR DESCRIPTION
Validation amount on `WorkerUnit` contract must have the option to be set to zero (0) because funds for reviewers - when validation is done by the reviewers protocol - are stored on the `Review` contract.

