### PR TITLE
Last features/fixes on reviewer protocol

### DIFF
--- a/src/reviewer-protocol/ThriveReview.sol
+++ b/src/reviewer-protocol/ThriveReview.sol
@@ -134,13 +134,11 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
     // Mapping of disputes: submissionId => Dispute object
     mapping(uint256 => Dispute) public disputes;
 
-
     // Scaler value for calculating ratios of accepted/rejected reviews
     uint256 constant SCALER = 10_000;
 
     // @dev Buffer time for canceling a dispute - arbitrary value set by dev
     uint256 constant _BUFFER_TIME_FOR_CANCELING_DISPUTE = 1 days;
-
 
     /**
      * Events
@@ -233,8 +231,6 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
         address indexed reviewer,
         uint256 amount
     );
-
-
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -793,7 +789,10 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
      * @notice Function to raise a dispute on a submission when user does not agree with final decision.
      * @param submissionId_ Submission ID.
      */
-    function raiseDisputeOnSubmission(uint256 submissionId_, string calldata disputeMetadata_) external {
+    function raiseDisputeOnSubmission(
+        uint256 submissionId_,
+        string calldata disputeMetadata_
+    ) external {
         // Get the submission from storage
         Submission storage submission = idToSubmission[submissionId_];
 
@@ -817,7 +816,6 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
             "User is not involved in the submission"
         );
 
-
         // Get dispute object from storage
         Dispute storage dispute = disputes[submissionId_];
 
@@ -829,7 +827,6 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
 
         // Save the dispute metadata
         dispute.disputeMetadata = disputeMetadata_;
-
 
         // Put submission in "DISPUTED" status
         submission.status = SubmissionStatus.DISPUTED;
@@ -860,7 +857,6 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
             "Submission is not in 'DISPUTED' status"
         );
 
-        
         // Get dispute object from storage
         Dispute storage dispute = disputes[submissionId_];
 
@@ -869,7 +865,6 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
 
         // Save the dispute resolution metadata
         dispute.disputeResolutionMetadata = disputeResolutionMetadata_;
-
 
         // Resolve the submission decision based on the resolvers' decision
         submission.decision = decision_;
@@ -900,7 +895,8 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
 
         // Require for the time-limit on disputing to have passed + some buffer time so that owner does not cancel the dispute too early
         require(
-            block.timestamp > submission.disputeDeadline + _BUFFER_TIME_FOR_CANCELING_DISPUTE,
+            block.timestamp
+                > submission.disputeDeadline + _BUFFER_TIME_FOR_CANCELING_DISPUTE,
             "Dispute deadline has not passed"
         );
 

--- a/src/reviewer-protocol/ThriveReview.sol
+++ b/src/reviewer-protocol/ThriveReview.sol
@@ -1102,7 +1102,10 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
      * @return bool True if all submissions are paid out, false otherwise.
      */
     function allSubmissionsPaidOut() public view returns (bool) {
-        if (submissions.length == 0 && block.timestamp <= reviewConfiguration.submissionDeadline) {
+        if (
+            submissions.length == 0
+                && block.timestamp <= reviewConfiguration.submissionDeadline
+        ) {
             return false;
         }
 

--- a/src/reviewer-protocol/ThriveReview.sol
+++ b/src/reviewer-protocol/ThriveReview.sol
@@ -482,7 +482,7 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
      * @dev Previously created Review object is updated with new passed information.
      * @param review_ Review object containing the review metadata and decision.
      */
-    function createReview(Review calldata review_)
+    function submitReview(Review calldata review_)
         external
         onlyUserWithAtLeastOneBadge(reviewConfiguration.reviewerBadges)
     {

--- a/src/reviewer-protocol/ThriveReview.sol
+++ b/src/reviewer-protocol/ThriveReview.sol
@@ -1102,6 +1102,10 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
      * @return bool True if all submissions are paid out, false otherwise.
      */
     function allSubmissionsPaidOut() public view returns (bool) {
+        if (submissions.length == 0 && block.timestamp <= reviewConfiguration.submissionDeadline) {
+            return false;
+        }
+
         for (uint256 i = 0; i < submissions.length; i++) {
             if (submissions[i].status != SubmissionStatus.PAID_OUT) {
                 return false;

--- a/src/reviewer-protocol/ThriveReview.sol
+++ b/src/reviewer-protocol/ThriveReview.sol
@@ -788,6 +788,7 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
     /**
      * @notice Function to raise a dispute on a submission when user does not agree with final decision.
      * @param submissionId_ Submission ID.
+     * @param disputeMetadata_ Metadata detailing the reasons for raising dispute.
      */
     function raiseDisputeOnSubmission(
         uint256 submissionId_,
@@ -839,6 +840,7 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
      * @notice Function for resolving disputes on submissions by user holding dispute badge.
      * @param submissionId_ Submission ID.
      * @param decision_ Decision on the submission.
+     * @param disputeResolutionMetadata_ Metadata detailing reasons behind resolution decision.
      */
     function resolveDisputeOnSubmission(
         uint256 submissionId_,

--- a/src/reviewer-protocol/ThriveReview.sol
+++ b/src/reviewer-protocol/ThriveReview.sol
@@ -975,9 +975,9 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
         // Fetch the reviews of the submission
         uint256[] memory reviewIds = submissionReviews[submissionId_];
 
-        // Loop through the reviews for specific submission
+        // Loop through the reviews of a specific submission
         for (uint256 i = 0; i < reviewIds.length; i++) {
-            // Fetch the review from storage
+            // Fetch the review from storage and copy to memory
             Review memory review = reviews[reviewIds[i]];
 
             // Require that the user made the judgement that is the same as the final decision
@@ -1024,13 +1024,6 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
             );
         }
     }
-
-    ////////  Ask Rilind what view functions should be implemented
-    ////////////////
-    ////////////////
-    ////////////////
-    ////////////////
-    ////////////////
 
     /**
      * @notice Pays out the submission reserved funds to the submitter if his submission is ACCEPTED - otherwise return only a fraction of funds.

--- a/src/reviewer-protocol/ThriveReview.sol
+++ b/src/reviewer-protocol/ThriveReview.sol
@@ -131,6 +131,17 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
     // Mapping which describes if the user/address is involved in any submission either as a contributor or reviewer: userAddress => submissionId => true/false
     mapping(address => mapping(uint256 => bool)) public userInvolvedInSubmission;
 
+    // Mapping of disputes: submissionId => Dispute object
+    mapping(uint256 => Dispute) public disputes;
+
+
+    // Scaler value for calculating ratios of accepted/rejected reviews
+    uint256 constant SCALER = 10_000;
+
+    // @dev Buffer time for canceling a dispute - arbitrary value set by dev
+    uint256 constant _BUFFER_TIME_FOR_CANCELING_DISPUTE = 1 days;
+
+
     /**
      * Events
      */
@@ -223,8 +234,7 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
         uint256 amount
     );
 
-    // Scaler value for calculating ratios of accepted/rejected reviews
-    uint256 constant SCALER = 10_000;
+
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -783,7 +793,7 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
      * @notice Function to raise a dispute on a submission when user does not agree with final decision.
      * @param submissionId_ Submission ID.
      */
-    function raiseDisputeOnSubmission(uint256 submissionId_) external {
+    function raiseDisputeOnSubmission(uint256 submissionId_, string calldata disputeMetadata_) external {
         // Get the submission from storage
         Submission storage submission = idToSubmission[submissionId_];
 
@@ -807,6 +817,20 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
             "User is not involved in the submission"
         );
 
+
+        // Get dispute object from storage
+        Dispute storage dispute = disputes[submissionId_];
+
+        // Fill the dispute object
+        dispute.submissionId = submissionId_;
+
+        // Save the disputer's address
+        dispute.disputer = _msgSender();
+
+        // Save the dispute metadata
+        dispute.disputeMetadata = disputeMetadata_;
+
+
         // Put submission in "DISPUTED" status
         submission.status = SubmissionStatus.DISPUTED;
 
@@ -821,7 +845,8 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
      */
     function resolveDisputeOnSubmission(
         uint256 submissionId_,
-        Decision decision_
+        Decision decision_,
+        string calldata disputeResolutionMetadata_
     )
         external
         onlyUserWithAtLeastOneBadge(reviewConfiguration.disputeResolverBadges)
@@ -834,6 +859,17 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
             submission.status == SubmissionStatus.DISPUTED,
             "Submission is not in 'DISPUTED' status"
         );
+
+        
+        // Get dispute object from storage
+        Dispute storage dispute = disputes[submissionId_];
+
+        // Fill resolver data in dispute object
+        dispute.resolver = _msgSender();
+
+        // Save the dispute resolution metadata
+        dispute.disputeResolutionMetadata = disputeResolutionMetadata_;
+
 
         // Resolve the submission decision based on the resolvers' decision
         submission.decision = decision_;
@@ -864,7 +900,7 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
 
         // Require for the time-limit on disputing to have passed + some buffer time so that owner does not cancel the dispute too early
         require(
-            block.timestamp > submission.disputeDeadline + 1 days,
+            block.timestamp > submission.disputeDeadline + _BUFFER_TIME_FOR_CANCELING_DISPUTE,
             "Dispute deadline has not passed"
         );
 

--- a/src/reviewer-protocol/ThriveReview.sol
+++ b/src/reviewer-protocol/ThriveReview.sol
@@ -672,9 +672,10 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
      * @param submissionId_ Submission ID.
      * @param decision_ Decision on the submission.
      */
-    function reachDecisionOnSubmissionAsBadge(
+    function reachDecisionOnSubmissionAsJudge(
         uint256 submissionId_,
-        Decision decision_
+        Decision decision_,
+        string calldata judgeDecisionMetadata_
     )
         external
         onlyUserWithAtLeastOneBadge(reviewConfiguration.judgeBadges)
@@ -708,6 +709,9 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
 
         // Start dispute period
         submission.disputeDeadline = uint64(block.timestamp + 2 days);
+
+        // Save judge decision metadata (should contain reasoning behind the decision)
+        submission.judgeDecisionMetadata = judgeDecisionMetadata_;
 
         // Emit event
         emit SubmissionDecisionReachedAsBadge(

--- a/src/reviewer-protocol/ThriveReview.sol
+++ b/src/reviewer-protocol/ThriveReview.sol
@@ -1102,6 +1102,7 @@ contract ThriveReview is OwnableUpgradeable, IThriveReview {
      * @return bool True if all submissions are paid out, false otherwise.
      */
     function allSubmissionsPaidOut() public view returns (bool) {
+        // If there are no submissions and the deadline for submissions has not passed - then there were not any submissions to be paid out and they can still come
         if (
             submissions.length == 0
                 && block.timestamp <= reviewConfiguration.submissionDeadline

--- a/src/reviewer-protocol/interface/IThriveReview.sol
+++ b/src/reviewer-protocol/interface/IThriveReview.sol
@@ -62,6 +62,8 @@ interface IThriveReview {
         address contributor;
         // JSON object that contains the information shown to reviewers during the review process
         string submissionMetadata;
+        // Metadata containing judge decision on the submission - This is filled when a judge HAS TO finalize a submission.
+        string judgeDecisionMetadata;
         // Review decision on this submission - saved after conditions for reaching a verdict are met.
         Decision decision;
         // The status of the submission

--- a/src/reviewer-protocol/interface/IThriveReview.sol
+++ b/src/reviewer-protocol/interface/IThriveReview.sol
@@ -88,6 +88,20 @@ interface IThriveReview {
         ReviewStatus status;
     }
 
+    // Struct to store the details of a dispute.
+    struct Dispute {
+        // The id of the submission that is being disputed.
+        uint256 submissionId;
+        // The address of the user who is disputing the submission.
+        address disputer;
+        // The address of the user who is resolving the dispute.
+        address resolver;
+        // Metadata submitted by the disputer to explain the dispute.
+        string disputeMetadata;
+        // Metadata submitted by the resolver to explain the resolution.
+        string disputeResolutionMetadata;
+    }
+
     // Status of a ThriveReview submission
     enum SubmissionStatus {
         NONE,

--- a/test/reviewer-protocol/BasicTestConfigs.t.sol
+++ b/test/reviewer-protocol/BasicTestConfigs.t.sol
@@ -76,6 +76,7 @@ abstract contract BasicTestConfigs is Test {
             rejectedReviewsCount: 213,
             reviewDeadline: 1234,
             disputeDeadline: 0,
+            judgeDecisionMetadata: "",
             decision: IThriveReview.Decision.ACCEPTED,
             status: IThriveReview.SubmissionStatus.PENDING
         });

--- a/test/reviewer-protocol/e2e-tests/ThriveReview.e2e.t.sol
+++ b/test/reviewer-protocol/e2e-tests/ThriveReview.e2e.t.sol
@@ -478,7 +478,7 @@ contract ThriveReviewE2ETests is Test, BasicTestConfigs {
 
         // Raise dispute for submission 4
         vm.prank(reviewer3);
-        thriveReview.raiseDisputeOnSubmission(3);
+        thriveReview.raiseDisputeOnSubmission(3, "");
 
         // Check submission 4 status
         submissionStatus = thriveReview.getSubmissionStatus(3);
@@ -497,7 +497,7 @@ contract ThriveReviewE2ETests is Test, BasicTestConfigs {
 
         // Dispute badge resolves dispute
         thriveReview.resolveDisputeOnSubmission(
-            3, IThriveReview.Decision.ACCEPTED
+            3, IThriveReview.Decision.ACCEPTED, ""
         );
 
         // Check that submission 4 is finalized

--- a/test/reviewer-protocol/e2e-tests/ThriveReview.e2e.t.sol
+++ b/test/reviewer-protocol/e2e-tests/ThriveReview.e2e.t.sol
@@ -177,6 +177,7 @@ contract ThriveReviewE2ETests is Test, BasicTestConfigs {
             ,
             ,
             ,
+            ,
             IThriveReview.Decision decision,
             IThriveReview.SubmissionStatus submissionStatus
         ) = thriveReview.idToSubmission(0);
@@ -261,6 +262,7 @@ contract ThriveReviewE2ETests is Test, BasicTestConfigs {
             reviewCount,
             acceptedReviewsCount,
             rejectedReviewsCount,
+            ,
             ,
             ,
             ,
@@ -366,6 +368,7 @@ contract ThriveReviewE2ETests is Test, BasicTestConfigs {
             ,
             ,
             ,
+            ,
             decision,
             submissionStatus
         ) = thriveReview.idToSubmission(2);
@@ -461,8 +464,8 @@ contract ThriveReviewE2ETests is Test, BasicTestConfigs {
         vm.warp(currentBlockTimestamp + 10 days + 1);
 
         // We can judge the submission as a badge since decision is not reached after max reviews
-        thriveReview.reachDecisionOnSubmissionAsBadge(
-            3, IThriveReview.Decision.REJECTED
+        thriveReview.reachDecisionOnSubmissionAsJudge(
+            3, IThriveReview.Decision.REJECTED, ""
         );
 
         // Ensure submission 4 is in the correct state

--- a/test/reviewer-protocol/e2e-tests/ThriveReview.e2e.t.sol
+++ b/test/reviewer-protocol/e2e-tests/ThriveReview.e2e.t.sol
@@ -160,12 +160,12 @@ contract ThriveReviewE2ETests is Test, BasicTestConfigs {
         vm.prank(reviewer2);
         review.id = 2;
         review.decision = IThriveReview.Decision.REJECTED;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         vm.prank(reviewer2);
         review.id = 3;
         review.decision = IThriveReview.Decision.ACCEPTED;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Fetch first submission
         (
@@ -232,18 +232,18 @@ contract ThriveReviewE2ETests is Test, BasicTestConfigs {
         vm.prank(reviewer3);
         review.id = 6;
         review.decision = IThriveReview.Decision.ACCEPTED;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Reviewer 1 creates review for submission 1 and 2
         vm.prank(reviewer1);
         review.id = 0;
         review.decision = IThriveReview.Decision.REJECTED;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         vm.prank(reviewer1);
         review.id = 1;
         review.decision = IThriveReview.Decision.ACCEPTED;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Reviewer 3 commits to review submission 1
         vm.prank(reviewer3);
@@ -253,7 +253,7 @@ contract ThriveReviewE2ETests is Test, BasicTestConfigs {
         vm.prank(reviewer3);
         review.id = 7;
         review.decision = IThriveReview.Decision.REJECTED;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Fetch third submission
         (
@@ -304,7 +304,7 @@ contract ThriveReviewE2ETests is Test, BasicTestConfigs {
         vm.prank(reviewer3);
         review.id = 8;
         review.decision = IThriveReview.Decision.ACCEPTED;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Fetch second submission status
         decision = thriveReview.getSubmissionDecision(1);
@@ -328,13 +328,13 @@ contract ThriveReviewE2ETests is Test, BasicTestConfigs {
         vm.prank(reviewer4);
         review.id = 9;
         review.decision = IThriveReview.Decision.REJECTED;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Reviewer 1 creates review for submission 3
         vm.prank(reviewer1);
         review.id = 4;
         review.decision = IThriveReview.Decision.ACCEPTED;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Reviewer 4 commits to review submission 4
         vm.prank(reviewer4);
@@ -348,13 +348,13 @@ contract ThriveReviewE2ETests is Test, BasicTestConfigs {
         vm.prank(reviewer3);
         review.id = 11;
         review.decision = IThriveReview.Decision.REJECTED;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Reviewer 2 creates review for submission 3
         vm.prank(reviewer2);
         review.id = 5;
         review.decision = IThriveReview.Decision.ACCEPTED;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Fetch submission 3
         (
@@ -428,7 +428,7 @@ contract ThriveReviewE2ETests is Test, BasicTestConfigs {
         review.id = 10;
         review.decision = IThriveReview.Decision.REJECTED;
         vm.expectRevert("Review commitment deadline has passed");
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Reviewer 1 commits to review submission 4
         vm.prank(reviewer1);
@@ -438,7 +438,7 @@ contract ThriveReviewE2ETests is Test, BasicTestConfigs {
         vm.prank(reviewer1);
         review.id = 12;
         review.decision = IThriveReview.Decision.ACCEPTED;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Reviewer 2 commits to review submission 4
         vm.prank(reviewer2);
@@ -447,7 +447,7 @@ contract ThriveReviewE2ETests is Test, BasicTestConfigs {
         // Reviewer 2 creates review for submission 4
         vm.prank(reviewer2);
         review.id = 13;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Ensure submission 4 is in the correct state
         decision = thriveReview.getSubmissionDecision(3);

--- a/test/reviewer-protocol/unit-tests/ThriveReview.t.sol
+++ b/test/reviewer-protocol/unit-tests/ThriveReview.t.sol
@@ -2427,6 +2427,71 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         );
     }
 
+    function test_512_success_DisputeStorageObjectCorrectlyStored() public {
+        // Create a submission
+        thriveReview.createSubmission{value: SUBMITTER_LOCKED_FUNDS}(submission);
+
+        // Go to after review deadline so judge can make the decision
+        vm.warp(
+            currentBlockTimestamp + reviewConfiguration.reviewDeadlinePeriod + 1
+        );
+
+        // Finalize this submission as a judge badge
+        thriveReview.reachDecisionOnSubmissionAsJudge(
+            0,
+            IThriveReview.Decision.ACCEPTED,
+            "I think this submission should be accepted"
+        );
+
+        // Get submission decision
+        IThriveReview.Decision decision = thriveReview.getSubmissionDecision(0);
+        assertEq(
+            uint256(decision),
+            uint256(IThriveReview.Decision.ACCEPTED),
+            "Submission decision is not set correctly"
+        );
+
+        // Raise dispute
+        thriveReview.raiseDisputeOnSubmission(
+            0, "I think this submission should be rejected"
+        );
+
+        // Resolve dispute
+        thriveReview.resolveDisputeOnSubmission(
+            0,
+            IThriveReview.Decision.REJECTED,
+            "I think this submission should NOT be rejected"
+        );
+
+        // Get dispute object
+        (
+            uint256 submissionId,
+            address disputer,
+            address resolver,
+            string memory disputeMetadata,
+            string memory disputeResolutionMetadata
+        ) = thriveReview.disputes(0);
+
+        // Assert that the dispute object is stored correctly
+        assertEq(submissionId, 0, "Submission ID is not set correctly");
+        assertEq(
+            disputer, address(this), "Disputer address is not set correctly"
+        );
+        assertEq(
+            resolver, address(this), "Resolver address is not set correctly"
+        );
+        assertEq(
+            disputeMetadata,
+            "I think this submission should be rejected",
+            "Dispute metadata is not set correctly"
+        );
+        assertEq(
+            disputeResolutionMetadata,
+            "I think this submission should NOT be rejected",
+            "Dispute resolution metadata is not set correctly"
+        );
+    }
+
     receive() external payable {}
 }
 

--- a/test/reviewer-protocol/unit-tests/ThriveReview.t.sol
+++ b/test/reviewer-protocol/unit-tests/ThriveReview.t.sol
@@ -1843,7 +1843,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         );
 
         vm.expectRevert("Submission is not in 'FINALIZED' status");
-        thriveReview.raiseDisputeOnSubmission(0);
+        thriveReview.raiseDisputeOnSubmission(0, "");
     }
 
     function test_501_revert_FailToRaiseDisputeAfterDisputeDeadlinePasses()
@@ -1889,7 +1889,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.warp(currentBlockTimestamp + 2 days + 1);
 
         vm.expectRevert("Dispute deadline has passed");
-        thriveReview.raiseDisputeOnSubmission(0);
+        thriveReview.raiseDisputeOnSubmission(0, "");
     }
 
     function test_502_revert_FailToRaiseDisputeIfNotInvolvedInSubmission()
@@ -1933,7 +1933,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
 
         vm.expectRevert("User is not involved in the submission");
         vm.prank(address(0x3));
-        thriveReview.raiseDisputeOnSubmission(0);
+        thriveReview.raiseDisputeOnSubmission(0, "");
     }
 
     function test_503_success_RaiseDisputeOnSubmission() public {
@@ -1976,7 +1976,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         );
 
         // Raise dispute
-        thriveReview.raiseDisputeOnSubmission(0);
+        thriveReview.raiseDisputeOnSubmission(0, "");
 
         // Check that the submission is disputed
         IThriveReview.SubmissionStatus submissionStatusAfterDispute =
@@ -2020,7 +2020,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
 
         vm.expectRevert("Submission is not in 'DISPUTED' status");
         thriveReview.resolveDisputeOnSubmission(
-            0, IThriveReview.Decision.ACCEPTED
+            0, IThriveReview.Decision.ACCEPTED, ""
         );
     }
 
@@ -2080,7 +2080,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         );
 
         // Raise dispute
-        thriveReview.raiseDisputeOnSubmission(0);
+        thriveReview.raiseDisputeOnSubmission(0, "");
 
         // Check that the submission is disputed
         IThriveReview.SubmissionStatus submissionStatusAfterDispute =
@@ -2093,7 +2093,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
 
         // Resolve dispute
         thriveReview.resolveDisputeOnSubmission(
-            0, IThriveReview.Decision.REJECTED
+            0, IThriveReview.Decision.REJECTED, ""
         );
 
         // Check that the submission is resolved
@@ -2187,7 +2187,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReview.submitReview(review);
 
         // Raise dispute
-        thriveReview.raiseDisputeOnSubmission(0);
+        thriveReview.raiseDisputeOnSubmission(0, "");
 
         // Check that the submission is disputed
         IThriveReview.SubmissionStatus submissionStatusAfterDispute =
@@ -2238,7 +2238,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReview.submitReview(review);
 
         // Raise dispute
-        thriveReview.raiseDisputeOnSubmission(0);
+        thriveReview.raiseDisputeOnSubmission(0, "");
 
         // Check that the submission is disputed
         IThriveReview.SubmissionStatus submissionStatusAfterDispute =

--- a/test/reviewer-protocol/unit-tests/ThriveReview.t.sol
+++ b/test/reviewer-protocol/unit-tests/ThriveReview.t.sol
@@ -257,7 +257,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReview.commitToReview(0);
 
         // Create a review
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         vm.prank(address(0x1));
         // Commit to a review
@@ -266,7 +266,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x1));
         // Create a review
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         vm.prank(address(0x2));
         // Commit to a review
@@ -275,7 +275,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x2));
         // Create a review
         review.id = 2;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Check that the submission is finalized
         IThriveReview.Decision decision = thriveReview.getSubmissionDecision(0);
@@ -312,7 +312,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
 
         review.decision = IThriveReview.Decision.REJECTED;
         // Create a review
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         vm.prank(address(0x1));
         // Commit to a review
@@ -321,7 +321,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x1));
         // Create a review
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         vm.prank(address(0x2));
         // Commit to a review
@@ -330,7 +330,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x2));
         // Create a review
         review.id = 2;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Check that the submission is finalized
         IThriveReview.SubmissionStatus submissionStatus =
@@ -353,7 +353,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
 
         // Create a review
         review.id = 3;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         vm.prank(address(0x1));
         // Commit to a review
@@ -362,7 +362,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x1));
         // Create a review
         review.id = 4;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         vm.prank(address(0x2));
         // Commit to a review
@@ -371,7 +371,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x2));
         // Create a review
         review.id = 5;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Check that the submission is finalized
         submissionStatus = thriveReview.getSubmissionStatus(0);
@@ -556,7 +556,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReview.commitToReview(0);
 
         // Create a review
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         vm.expectRevert("Submission has reviews");
         thriveReview.updateSubmission(submission.submissionMetadata, 0);
@@ -574,7 +574,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReview.commitToReview(0);
 
         // Create a review
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         vm.prank(address(0x1));
         // Commit to a review
@@ -583,7 +583,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x1));
         // Create a review
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         vm.prank(address(0x2));
         // Commit to a review
@@ -592,7 +592,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x2));
         // Create a review
         review.id = 2;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Check that the submission is finalized
         IThriveReview.SubmissionStatus submissionStatus =
@@ -725,7 +725,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReview.commitToReview(0);
 
         // Create a review
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         vm.prank(address(0x1));
         // Commit to a review
@@ -734,7 +734,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x1));
         // Create a review
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         vm.prank(address(0x2));
         // Commit to a review
@@ -743,7 +743,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x2));
         // Create a review
         review.id = 2;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Check that the submission is finalized
         IThriveReview.SubmissionStatus submissionStatus =
@@ -763,7 +763,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReview.createSubmission{value: SUBMITTER_LOCKED_FUNDS}(submission);
 
         vm.expectRevert("User has not committed to this review");
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
     }
 
     function test_206_revert_FailToCreateReviewForSubmissionThatIsNotPending()
@@ -778,7 +778,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
 
         // Create a review
         vm.prank(address(0x1));
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x2));
@@ -787,7 +787,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x2));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x3));
@@ -801,7 +801,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x4));
         review.id = 3;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Now submission has enough reviews to be judged on
         // Check that the submission is finalized
@@ -817,7 +817,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x3));
         vm.expectRevert("Submission is not in 'PENDING' status");
         review.id = 2;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
     }
 
     function test_207_revert_FailToCreateReviewByUserWhoDidNotCommitTheSameReview(
@@ -835,7 +835,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // User can not create review committed by someone else
         vm.expectRevert("User is not the committer of this review");
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
     }
 
     function test_208_revert_FailToCreateReviewAfterReviewCommitmentDeadline()
@@ -854,7 +854,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         );
 
         vm.expectRevert("Review commitment deadline has passed");
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
     }
 
     function test_209_revert_FailToCreateReviewAfterReviewDeadline() public {
@@ -875,7 +875,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         );
 
         vm.expectRevert("Review deadline has passed");
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
     }
 
     function test_210_revert_FailToCreateReviewWithNonAcceptedDecision()
@@ -892,7 +892,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.expectRevert(
             "Review decision must be either 'ACCEPTED' or 'REJECTED'"
         );
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
     }
 
     function test_211_success_CreateReviewAfterCommittingToIt() public {
@@ -903,7 +903,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReview.commitToReview(0);
 
         // Create a review
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Get the review
         (
@@ -1068,7 +1068,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x1));
         thriveReview.commitToReview(0);
         // Create review by address(0x1)
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         vm.warp(
             currentBlockTimestamp + reviewConfiguration.reviewCommitmentPeriod
@@ -1113,7 +1113,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReview.commitToReview(0);
 
         // Create a review
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         vm.prank(address(0x1));
         // Commit to a review
@@ -1122,7 +1122,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x1));
         // Create a review
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         uint256 balanceBeforeClaimingReward = address(this).balance;
         uint256 balanceAddress1BeforeClaimingReward = address(0x1).balance;
@@ -1138,7 +1138,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x2));
         // Create a review
         review.id = 2;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Address 3 makes the right decision
         review.decision = IThriveReview.Decision.ACCEPTED;
@@ -1149,7 +1149,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x3));
         // Create a review
         review.id = 3;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Check that the submission is ACCEPTED
         IThriveReview.Decision decision = thriveReview.getSubmissionDecision(0);
@@ -1209,7 +1209,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReview.commitToReview(0);
 
         // Create a review
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         vm.prank(address(0x1));
         // Commit to a review
@@ -1218,7 +1218,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x1));
         // Create a review
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         uint256 balanceBeforeClaimingReward = address(this).balance;
         uint256 balanceAddress1BeforeClaimingReward = address(0x1).balance;
@@ -1234,7 +1234,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x2));
         // Create a review
         review.id = 2;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Address 3 makes the right decision
         review.decision = IThriveReview.Decision.REJECTED;
@@ -1245,7 +1245,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x3));
         // Create a review
         review.id = 3;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Check that the submission is finalized
         IThriveReview.Decision decision = thriveReview.getSubmissionDecision(0);
@@ -1350,7 +1350,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReviewWithoutWorkUnit.commitToReview(0);
 
         // Create a review
-        thriveReviewWithoutWorkUnit.createReview(review);
+        thriveReviewWithoutWorkUnit.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x1));
@@ -1359,7 +1359,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x1));
         review.id = 1;
-        thriveReviewWithoutWorkUnit.createReview(review);
+        thriveReviewWithoutWorkUnit.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x2));
@@ -1368,7 +1368,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x2));
         review.id = 2;
-        thriveReviewWithoutWorkUnit.createReview(review);
+        thriveReviewWithoutWorkUnit.submitReview(review);
 
         // Check that the submission is finalized
         IThriveReview.SubmissionStatus submissionStatus =
@@ -1418,7 +1418,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
 
         // Create a review
         vm.prank(address(0x1));
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x2));
@@ -1427,7 +1427,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x2));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Make following reviews REJECTED
         review.decision = IThriveReview.Decision.REJECTED;
@@ -1439,7 +1439,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x3));
         review.id = 2;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x4));
@@ -1448,7 +1448,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x4));
         review.id = 3;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Check that the submission is still pending because there is no consensus on decision
         IThriveReview.Decision decision = thriveReview.getSubmissionDecision(0);
@@ -1496,7 +1496,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
 
         // Create a review
         vm.prank(address(0x1));
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Change the users decision to REJECTED
         review.decision = IThriveReview.Decision.REJECTED;
@@ -1507,7 +1507,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x2));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Users balances before distributing reviewer rewards
         uint256 balanceAddress1BeforeClaimingReward = address(0x1).balance;
@@ -1555,7 +1555,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
 
         // Create a review
         vm.prank(address(0x1));
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x2));
@@ -1564,7 +1564,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x2));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Go to right after the review deadline
         vm.warp(
@@ -1603,7 +1603,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
 
         // Create a review
         vm.prank(address(0x1));
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x2));
@@ -1612,7 +1612,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x2));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Revert on finalizing the submission
         vm.expectRevert(
@@ -1634,7 +1634,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
 
         // Create a review
         vm.prank(address(0x1));
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x2));
@@ -1643,7 +1643,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x2));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Go to right after the review deadline
         vm.warp(
@@ -1669,7 +1669,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
 
         // Create a review
         vm.prank(address(0x1));
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x2));
@@ -1678,7 +1678,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x2));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x3));
@@ -1687,7 +1687,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x3));
         review.id = 2;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Check that the submission is still finalized
         IThriveReview.Decision decision = thriveReview.getSubmissionDecision(0);
@@ -1720,7 +1720,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
 
         // Create a review
         vm.prank(address(0x1));
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x2));
@@ -1729,7 +1729,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x2));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Now review as a contract account
         FailedDistributionExampleContract failedDistributionExampleContract =
@@ -1819,7 +1819,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReview.commitToReview(0);
 
         // Create a review
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x1));
@@ -1828,7 +1828,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x1));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Check that the submission is still pending
         IThriveReview.SubmissionStatus submissionStatus =
@@ -1853,7 +1853,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReview.commitToReview(0);
 
         // Create a review
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x1));
@@ -1862,7 +1862,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x1));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x2));
@@ -1871,7 +1871,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x2));
         review.id = 2;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Check that the submission is finalized
         IThriveReview.SubmissionStatus submissionStatus =
@@ -1899,7 +1899,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReview.commitToReview(0);
 
         // Create a review
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x1));
@@ -1908,7 +1908,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x1));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x2));
@@ -1917,7 +1917,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x2));
         review.id = 2;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Check that the submission is finalized
         IThriveReview.SubmissionStatus submissionStatus =
@@ -1943,7 +1943,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
 
         // Create a review
         vm.prank(address(0x1));
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x2));
@@ -1952,7 +1952,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x2));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x3));
@@ -1961,7 +1961,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x3));
         review.id = 2;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Check that the submission is finalized
         IThriveReview.SubmissionStatus submissionStatus =
@@ -1995,7 +1995,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReview.commitToReview(0);
 
         // Create a review
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x1));
@@ -2004,7 +2004,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x1));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Check that the submission is still pending
         IThriveReview.SubmissionStatus submissionStatus =
@@ -2033,7 +2033,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
 
         // Create a review
         vm.prank(address(0x1));
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x2));
@@ -2042,7 +2042,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x2));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x3));
@@ -2052,7 +2052,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x3));
         review.id = 2;
         review.decision = IThriveReview.Decision.REJECTED;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x4));
@@ -2062,7 +2062,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.prank(address(0x4));
         review.id = 3;
         review.decision = IThriveReview.Decision.ACCEPTED;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // User 0x3 balance before dispute resolution
         uint256 balanceAddress3BeforeDispute = address(0x3).balance;
@@ -2129,7 +2129,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReview.commitToReview(0);
 
         // Create a review
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x1));
@@ -2138,7 +2138,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x1));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Check that the submission is still pending
         IThriveReview.SubmissionStatus submissionStatus =
@@ -2163,7 +2163,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
 
         // Create a review
         vm.prank(address(0x1));
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x2));
@@ -2172,7 +2172,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x2));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x3));
@@ -2181,7 +2181,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x3));
         review.id = 2;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Raise dispute
         thriveReview.raiseDisputeOnSubmission(0);
@@ -2214,7 +2214,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
 
         // Create a review
         vm.prank(address(0x1));
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x2));
@@ -2223,7 +2223,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x2));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x3));
@@ -2232,7 +2232,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x3));
         review.id = 2;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Raise dispute
         thriveReview.raiseDisputeOnSubmission(0);
@@ -2293,7 +2293,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReview.commitToReview(0);
 
         // Create a review
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x1));
@@ -2302,7 +2302,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x1));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Check that the submission is still pending
         IThriveReview.SubmissionStatus submissionStatus =
@@ -2329,7 +2329,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReview.commitToReview(0);
 
         // Create a review
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x1));
@@ -2338,7 +2338,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x1));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Go to right after the review deadline
         vm.warp(
@@ -2382,7 +2382,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         thriveReview.commitToReview(0);
 
         // Create a review
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Commit to review
         vm.prank(address(0x1));
@@ -2391,7 +2391,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         // Create a review
         vm.prank(address(0x1));
         review.id = 1;
-        thriveReview.createReview(review);
+        thriveReview.submitReview(review);
 
         // Balance of address 0x1 before getting reward
         uint256 balanceAddress1BeforeClaimingReward = address(0x1).balance;
@@ -2443,7 +2443,7 @@ contract FailedDistributionExampleContract {
         IThriveReview.Review calldata review_
     ) public {
         thriveReview.commitToReview(submissionId_);
-        thriveReview.createReview(review_);
+        thriveReview.submitReview(review_);
     }
 
     function claimFailedDistributionFunds() public {

--- a/test/reviewer-protocol/unit-tests/ThriveReview.t.sol
+++ b/test/reviewer-protocol/unit-tests/ThriveReview.t.sol
@@ -438,6 +438,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
             ,
             address contributor,
             string memory submissionMetadata,
+            ,
             IThriveReview.Decision decision,
             IThriveReview.SubmissionStatus status
         ) = thriveReview.idToSubmission(0);
@@ -501,6 +502,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
             ,
             ,
             string memory submissionMetadata,
+            ,
             IThriveReview.Decision decision,
             IThriveReview.SubmissionStatus status
         ) = thriveReview.idToSubmission(0);
@@ -947,6 +949,7 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
             uint64 reviewCount,
             uint64 acceptedReviewCount,
             uint64 rejectedReviewCount,
+            ,
             ,
             ,
             ,
@@ -1466,8 +1469,8 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         );
 
         // Finalize this submission as a judge badge
-        thriveReview.reachDecisionOnSubmissionAsBadge(
-            0, IThriveReview.Decision.ACCEPTED
+        thriveReview.reachDecisionOnSubmissionAsJudge(
+            0, IThriveReview.Decision.ACCEPTED, ""
         );
 
         // Check that the submission is still pending because there is no consensus on decision
@@ -1516,8 +1519,8 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.warp(
             currentBlockTimestamp + reviewConfiguration.reviewDeadlinePeriod + 1
         );
-        thriveReview.reachDecisionOnSubmissionAsBadge(
-            0, IThriveReview.Decision.REJECTED
+        thriveReview.reachDecisionOnSubmissionAsJudge(
+            0, IThriveReview.Decision.REJECTED, ""
         );
 
         // Go to after dispute deadline
@@ -1572,8 +1575,8 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         );
 
         // Finalize this submission as a judge badge
-        thriveReview.reachDecisionOnSubmissionAsBadge(
-            0, IThriveReview.Decision.ACCEPTED
+        thriveReview.reachDecisionOnSubmissionAsJudge(
+            0, IThriveReview.Decision.ACCEPTED, ""
         );
 
         // Check that the submission is still pending because there is no consensus on decision
@@ -1618,8 +1621,8 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         vm.expectRevert(
             "Submission has not reached requirements for a final decision as badge"
         );
-        thriveReview.reachDecisionOnSubmissionAsBadge(
-            0, IThriveReview.Decision.ACCEPTED
+        thriveReview.reachDecisionOnSubmissionAsJudge(
+            0, IThriveReview.Decision.ACCEPTED, ""
         );
     }
 
@@ -1652,8 +1655,8 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
 
         // Revert to finalize the submission with no proper decision
         vm.expectRevert("Decision must be either 'ACCEPTED' or 'REJECTED'");
-        thriveReview.reachDecisionOnSubmissionAsBadge(
-            0, IThriveReview.Decision.NONE
+        thriveReview.reachDecisionOnSubmissionAsJudge(
+            0, IThriveReview.Decision.NONE, ""
         );
     }
 
@@ -1705,8 +1708,8 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         );
 
         vm.expectRevert("Submission is not in 'PENDING' status");
-        thriveReview.reachDecisionOnSubmissionAsBadge(
-            0, IThriveReview.Decision.ACCEPTED
+        thriveReview.reachDecisionOnSubmissionAsJudge(
+            0, IThriveReview.Decision.ACCEPTED, ""
         );
     }
 
@@ -2346,8 +2349,8 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         );
 
         // Finalize this submission as a judge badge
-        thriveReview.reachDecisionOnSubmissionAsBadge(
-            0, IThriveReview.Decision.ACCEPTED
+        thriveReview.reachDecisionOnSubmissionAsJudge(
+            0, IThriveReview.Decision.ACCEPTED, ""
         );
 
         // Check that the submission is still pending because there is no consensus on decision
@@ -2402,8 +2405,8 @@ contract ThriveReviewUnitTests is Test, BasicTestConfigs {
         );
 
         // Finalize this submission as a judge badge
-        thriveReview.reachDecisionOnSubmissionAsBadge(
-            0, IThriveReview.Decision.ACCEPTED
+        thriveReview.reachDecisionOnSubmissionAsJudge(
+            0, IThriveReview.Decision.ACCEPTED, ""
         );
 
         // Go to after dispute deadline


### PR DESCRIPTION
Here we will deploy last fixes we noticed in `ThriveReviewFactory` and `ThriveReview` contracts as well as tests.

- `createReview` function is now named `submitReview` for clarity (there was confussion on demo).
- Dispute object is created per submission for data/metadata on dispute process.
- Buffer time is added for canceling disputes to give enough time to dispute resolver to make a decision (subjective buffer time, probably should be changed before deploying)