### PR TITLE
Update yield logic and total required amount in review factory

### DIFF
--- a/src/ThriveStakingBase.sol
+++ b/src/ThriveStakingBase.sol
@@ -47,6 +47,7 @@ abstract contract ThriveStakingBase is
     event Staked(address indexed user, uint256 amount);
     event Withdrawn(address indexed user, uint256 principal, uint256 yield);
     event YieldClaimed(address indexed user, uint256 yield, uint256 epoch);
+    event YieldStaked(address indexed user, uint256 amount, uint256 epoch);
 
     struct StakingDetails {
         uint256 firstHalfAmount;
@@ -72,6 +73,7 @@ abstract contract ThriveStakingBase is
 
     mapping(address => StakingDetails) public stakers;
     mapping(address => mapping(uint256 => bool)) public claimedEpoch;
+    mapping(address => uint256) public claimableYield;
 
     function _initialize(
         address _token,
@@ -134,7 +136,7 @@ abstract contract ThriveStakingBase is
     function calculateYield(address staker)
         public
         view
-        returns (uint256 claimableYield, uint256 ongoingYield)
+        returns (uint256 totalClaimableYield, uint256 ongoingYield)
     {
         StakingDetails memory details = stakers[staker];
         uint256 currentEpochIndex = currentEpoch();
@@ -144,54 +146,78 @@ abstract contract ThriveStakingBase is
             return (0, 0);
         }
 
-        uint256 epochStartTimestamp =
-            epochStart + (details.epoch * EPOCH_DURATION);
-        uint256 epochEndTimestamp = epochStartTimestamp + EPOCH_DURATION;
-        uint256 effectiveTime = block.timestamp < epochEndTimestamp
-            ? block.timestamp
-            : epochEndTimestamp;
+        totalClaimableYield = claimableYield[staker];
+        uint256 epochsElapsed = currentEpochIndex > details.epoch
+            ? currentEpochIndex - details.epoch
+            : 0;
 
-        uint256 yieldFirst = 0;
-        uint256 yieldSecond = 0;
+        if (epochsElapsed > 0) {
+            uint256 yieldPerEpochFirst =
+                details.firstHalfAmount * yieldRate * EPOCH_DURATION / 1e18;
+            uint256 yieldPerEpochSecond = details.secondHalfAmount * yieldRate
+                * EPOCH_DURATION / (2 * 1e18);
+            uint256 totalYieldPerEpoch =
+                yieldPerEpochFirst + yieldPerEpochSecond;
+
+            totalClaimableYield += totalYieldPerEpoch * epochsElapsed;
+
+            uint256 firstEpochStart = details.firstHalfTimestamp;
+            uint256 firstEpochEnd =
+                epochStart + ((details.epoch + 1) * EPOCH_DURATION);
+            uint256 firstEpochYieldFirst = details.firstHalfAmount * yieldRate
+                * (firstEpochEnd - firstEpochStart) / 1e18;
+            uint256 firstEpochYieldSecond = details.secondHalfAmount * yieldRate
+                * (firstEpochEnd - details.secondHalfTimestamp) / (2 * 1e18);
+
+            totalClaimableYield -= (
+                totalYieldPerEpoch
+                    - (firstEpochYieldFirst + firstEpochYieldSecond)
+            );
+        }
+
+        if (totalStaked > 0) {
+            uint256 currentEpochStart =
+                epochStart + (currentEpochIndex * EPOCH_DURATION);
+            uint256 effectiveTime = block.timestamp - currentEpochStart;
+
+            if (epochsElapsed == 0) {
+                effectiveTime = block.timestamp - details.firstHalfTimestamp;
+                ongoingYield +=
+                    details.firstHalfAmount * yieldRate * effectiveTime / 1e18;
+                ongoingYield += details.secondHalfAmount * yieldRate
+                    * effectiveTime / (2 * 1e18);
+            } else {
+                ongoingYield += totalStaked * yieldRate * effectiveTime / 1e18;
+            }
+        }
+
+        return (totalClaimableYield, ongoingYield);
+    }
+
+    function _updateStakeAndYield(address user) internal {
+        StakingDetails storage details = stakers[user];
+        uint256 currentEpochIndex = currentEpoch();
+        uint256 totalStaked = details.firstHalfAmount + details.secondHalfAmount;
 
         if (
-            details.firstHalfAmount > 0
-                && effectiveTime > details.firstHalfTimestamp
+            totalStaked < minStakingAmount || details.epoch >= currentEpochIndex
         ) {
-            yieldFirst = (
-                details.firstHalfAmount * yieldRate
-                    * (effectiveTime - details.firstHalfTimestamp)
-            ) / 1e18;
+            return;
         }
 
-        if (
-            details.secondHalfAmount > 0
-                && effectiveTime > details.secondHalfTimestamp
-        ) {
-            yieldSecond = (
-                details.secondHalfAmount * yieldRate
-                    * (effectiveTime - details.secondHalfTimestamp)
-            ) / (2 * 1e18);
-        }
+        (uint256 newClaimableYield,) = calculateYield(user);
+        claimableYield[user] = newClaimableYield;
 
-        uint256 totalYield = yieldFirst + yieldSecond;
-
-        if (details.epoch == currentEpochIndex) {
-            ongoingYield = totalYield;
-        }
-
-        if (
-            currentEpochIndex > details.epoch && currentEpochIndex > 0
-                && details.epoch == currentEpochIndex - 1
-                && !claimedEpoch[staker][details.epoch]
-        ) {
-            claimableYield = totalYield;
-        }
-
-        return (claimableYield, ongoingYield);
+        details.firstHalfAmount = totalStaked;
+        details.secondHalfAmount = 0;
+        details.firstHalfTimestamp =
+            epochStart + (currentEpochIndex * EPOCH_DURATION);
+        details.epoch = currentEpochIndex;
     }
 
     function withdraw() external nonReentrant {
+        _updateStakeAndYield(msg.sender);
+
         StakingDetails storage details = stakers[msg.sender];
         uint256 totalStaked = details.firstHalfAmount + details.secondHalfAmount;
         require(
@@ -200,9 +226,10 @@ abstract contract ThriveStakingBase is
         );
         require(totalStaked > 0, "ThriveProtocol: no staked tokens");
 
-        uint256 claimableYield = 0;
-        if (currentEpoch() > details.epoch) {
-            (claimableYield,) = calculateYield(msg.sender);
+        uint256 amountToWithdraw = claimableYield[msg.sender];
+
+        if (amountToWithdraw > 0) {
+            claimableYield[msg.sender] = 0;
         }
 
         details.firstHalfAmount = 0;
@@ -210,43 +237,72 @@ abstract contract ThriveStakingBase is
         details.epoch = 0;
 
         if (token == address(0)) {
-            _transferAmountStaked(msg.sender, totalStaked + claimableYield);
+            _transferAmountStaked(msg.sender, totalStaked + amountToWithdraw);
         } else {
-            _transferNative(msg.sender, claimableYield);
+            if (amountToWithdraw > 0) {
+                _transferNative(msg.sender, amountToWithdraw);
+            }
             _transferAmountStaked(msg.sender, totalStaked);
         }
 
-        emit Withdrawn(msg.sender, totalStaked, claimableYield);
+        emit Withdrawn(msg.sender, totalStaked, amountToWithdraw);
     }
 
     function claimYield() external nonReentrant {
+        _updateStakeAndYield(msg.sender);
+
         StakingDetails storage details = stakers[msg.sender];
         uint256 totalStaked = details.firstHalfAmount + details.secondHalfAmount;
-
-        require(
-            !claimedEpoch[msg.sender][details.epoch],
-            "ThriveProtocol: yield already claimed"
-        );
         require(totalStaked > 0, "ThriveProtocol: no staked tokens");
         require(
             totalStaked >= minStakingAmount,
             "ThriveProtocol: stake below minimum"
         );
+
+        uint256 amountToClaim = claimableYield[msg.sender];
+        require(amountToClaim > 0, "ThriveProtocol: no yield to claim");
+
+        claimableYield[msg.sender] = 0;
+        _transferNative(msg.sender, amountToClaim);
+        emit YieldClaimed(msg.sender, amountToClaim, currentEpoch() - 1);
+    }
+
+    function stakeYield() external nonReentrant {
+        _updateStakeAndYield(msg.sender);
+
+        StakingDetails storage details = stakers[msg.sender];
+        uint256 totalStaked = details.firstHalfAmount + details.secondHalfAmount;
+        require(totalStaked > 0, "ThriveProtocol: no staked tokens");
         require(
-            currentEpoch() > details.epoch, "ThriveProtocol: epoch not finished"
+            totalStaked >= minStakingAmount,
+            "ThriveProtocol: stake below minimum"
         );
 
-        (uint256 claimableYield,) = calculateYield(msg.sender);
-        require(claimableYield > 0, "ThriveProtocol: no yield to claim");
+        uint256 amountToStake = claimableYield[msg.sender];
+        require(amountToStake > 0, "ThriveProtocol: no yield to stake");
 
-        claimedEpoch[msg.sender][details.epoch] = true;
+        claimableYield[msg.sender] = 0;
 
-        _transferNative(msg.sender, claimableYield);
-        emit YieldClaimed(msg.sender, claimableYield, details.epoch);
+        uint256 epochPhaseStart = epochStart + (details.epoch * EPOCH_DURATION);
+        if (block.timestamp < epochPhaseStart + HALF_EPOCH_DURATION) {
+            details.firstHalfTimestamp = (
+                details.firstHalfAmount * details.firstHalfTimestamp
+                    + amountToStake * block.timestamp
+            ) / (details.firstHalfAmount + amountToStake);
+            details.firstHalfAmount += amountToStake;
+        } else {
+            if (details.secondHalfAmount == 0) {
+                details.secondHalfTimestamp = block.timestamp;
+            } else {
+                details.secondHalfTimestamp = (
+                    details.secondHalfAmount * details.secondHalfTimestamp
+                        + amountToStake * block.timestamp
+                ) / (details.secondHalfAmount + amountToStake);
+            }
+            details.secondHalfAmount += amountToStake;
+        }
 
-        details.epoch = currentEpoch();
-        details.firstHalfAmount = totalStaked;
-        details.secondHalfAmount = 0;
+        emit YieldStaked(msg.sender, amountToStake, details.epoch);
     }
 
     function stake(uint256 amount) external payable nonReentrant {
@@ -254,16 +310,12 @@ abstract contract ThriveStakingBase is
     }
 
     function _stake(uint256 amount) internal virtual {
-        uint256 epochIndex = currentEpoch();
-        StakingDetails storage details = stakers[msg.sender];
-        uint256 currentTotal =
-            details.firstHalfAmount + details.secondHalfAmount;
-        require(
-            currentTotal == 0 || details.epoch == epochIndex,
-            "ThriveProtocol: finalize previous epoch first"
-        );
+        _updateStakeAndYield(msg.sender);
 
+        StakingDetails storage details = stakers[msg.sender];
+        uint256 epochIndex = currentEpoch();
         uint256 epochPhaseStart = epochStart + (epochIndex * EPOCH_DURATION);
+
         if (block.timestamp < epochPhaseStart + HALF_EPOCH_DURATION) {
             if (details.firstHalfAmount == 0) {
                 details.firstHalfTimestamp = block.timestamp;

--- a/src/ThriveStakingBase.sol
+++ b/src/ThriveStakingBase.sol
@@ -220,10 +220,6 @@ abstract contract ThriveStakingBase is
 
         StakingDetails storage details = stakers[msg.sender];
         uint256 totalStaked = details.firstHalfAmount + details.secondHalfAmount;
-        require(
-            totalStaked >= minStakingAmount,
-            "ThriveProtocol: stake below minimum"
-        );
         require(totalStaked > 0, "ThriveProtocol: no staked tokens");
 
         uint256 amountToWithdraw = claimableYield[msg.sender];

--- a/src/interface/IThriveWorkerUnitFactory.sol
+++ b/src/interface/IThriveWorkerUnitFactory.sol
@@ -47,4 +47,11 @@ interface IThriveWorkerUnitFactory {
         external
         payable
         returns (address);
+
+    function getRequiredNativeFunds(
+        uint256 _rewardAmount,
+        uint256 _maxRewards,
+        uint256 _validationRewardAmount,
+        address _rewardToken
+    ) external pure returns (uint256);
 }

--- a/src/reviewer-protocol/ThriveReviewFactory.sol
+++ b/src/reviewer-protocol/ThriveReviewFactory.sol
@@ -135,6 +135,28 @@ contract ThriveReviewFactory is OwnableUpgradeable, UUPSUpgradeable {
         IThriveReview.ReviewConfiguration memory reviewConfiguration_,
         address thriveReviewOwner_
     ) external payable returns (address, address) {
+        // Calculate required amount for the worker unit
+        uint256 requiredNativeFundsForWorkerUnit = IThriveWorkerUnitFactory(
+            thriveWorkerUnitFactory
+        ).getRequiredNativeFunds(
+            workUnitArgs_.rewardAmount,
+            workUnitArgs_.maxRewards,
+            workUnitArgs_.validationRewardAmount,
+            workUnitArgs_.rewardToken
+        );
+
+        // Total required amount
+        uint256 totalRequired = reviewConfiguration_
+            .reviewerRewardsTotalAllocation + requiredNativeFundsForWorkerUnit;
+        require(
+            msg.value >= totalRequired,
+            "ThriveReviewFactory: Insufficient funds for review and worker unit"
+        );
+
+        // Allocations
+        uint256 reviewContractAllocation =
+            reviewConfiguration_.reviewerRewardsTotalAllocation;
+        uint256 workUnitAllocation = requiredNativeFundsForWorkerUnit;
         // Require enough funds are sent to payout the reward for reviewers
         require(
             msg.value >= reviewConfiguration_.reviewerRewardsTotalAllocation,
@@ -149,10 +171,6 @@ contract ThriveReviewFactory is OwnableUpgradeable, UUPSUpgradeable {
                     * reviewConfiguration_.maximumSubmissions,
             "ThriveReviewFactory: Insufficient funds to allocate rewards for reviewers"
         );
-
-        uint256 reviewContractAllocation =
-            reviewConfiguration_.reviewerRewardsTotalAllocation;
-        uint256 workUnitAllocation = msg.value - reviewContractAllocation;
 
         // Create a new ThriveReview contract by cloning existing implementation.
         address thriveReviewContract =

--- a/test/ThriveStakingIERC20.t.sol
+++ b/test/ThriveStakingIERC20.t.sol
@@ -120,8 +120,7 @@ contract ThriveStakingERC20Test is Test {
         uint256 expectedYield =
             (minStakingAmount * yieldRate * timeStaked) / 1e18;
 
-        (uint256 claimableYield, uint256 ongoingYield) =
-            staking.calculateYield(user);
+        (uint256 claimableYield,) = staking.calculateYield(user);
         assertEq(
             claimableYield,
             expectedYield,
@@ -144,8 +143,7 @@ contract ThriveStakingERC20Test is Test {
         uint256 expectedYield =
             (minStakingAmount * yieldRate * timeStaked) / (2 * 1e18);
 
-        (uint256 claimableYield, uint256 ongoingYield) =
-            staking.calculateYield(user);
+        (uint256 claimableYield,) = staking.calculateYield(user);
         assertEq(
             claimableYield,
             expectedYield,

--- a/test/ThriveStakingIERC20.t.sol
+++ b/test/ThriveStakingIERC20.t.sol
@@ -8,14 +8,14 @@ import {ERC1967Proxy} from
 import {ThriveProtocolAccessControl} from "src/ThriveProtocolAccessControl.sol";
 import {MockERC20} from "test/mock/MockERC20.sol";
 
-/// @dev Test suite for ERC20 token staking logic.
+/// @dev Test suite for ERC20 token staking logic with automatic rollover.
 contract ThriveStakingERC20Test is Test {
     ThriveStakingIERC20 staking;
     MockERC20 public mockToken;
     ThriveProtocolAccessControl public accessControl;
     address admin = address(0xABCD);
     address user = address(0xBEEF);
-    uint256 yieldRate = 100;
+    uint256 yieldRate = 38_580_246_913; // Per-second rate for 10% monthly yield (0.1 * 1e18 / 2,592,000)
     uint256 minStakingAmount = 1 ether;
     uint256 EPOCH_DURATION = 30 days;
     uint256 HALF_EPOCH_DURATION = 15 days;
@@ -57,9 +57,9 @@ contract ThriveStakingERC20Test is Test {
 
     function testStakeRevertsIfNativeSent() public {
         vm.prank(user);
-        mockToken.transfer(user, 10 ether);
-        mockToken.approve(user, 10 ether);
-
+        mockToken.approve(address(staking), minStakingAmount);
+        vm.prank(user);
+        vm.deal(user, 10 ether);
         vm.expectRevert(
             "ThriveProtocol: native should not be sent for ERC20 staking"
         );
@@ -69,7 +69,6 @@ contract ThriveStakingERC20Test is Test {
     function testStakeRevertsForBelowMin() public {
         vm.prank(user);
         mockToken.approve(address(staking), 0.5 ether);
-
         vm.prank(user);
         vm.expectRevert("ThriveProtocol: below minimum stake");
         staking.stake(0.5 ether);
@@ -78,9 +77,9 @@ contract ThriveStakingERC20Test is Test {
     function testStakeSuccess() public {
         vm.prank(user);
         mockToken.approve(address(staking), minStakingAmount);
-
         vm.prank(user);
         staking.stake(minStakingAmount);
+
         (
             uint256 firstHalf,
             uint256 firstHalfTimestamp,
@@ -88,7 +87,6 @@ contract ThriveStakingERC20Test is Test {
             uint256 secondHalfTimestamp,
             uint256 epoch
         ) = staking.stakers(user);
-
         uint256 currentEpoch = staking.currentEpoch();
 
         assertEq(firstHalf, minStakingAmount);
@@ -101,7 +99,6 @@ contract ThriveStakingERC20Test is Test {
     function testGetStakedAmount() public {
         vm.prank(user);
         mockToken.approve(address(staking), 2 ether);
-
         vm.prank(user);
         staking.stake(2 ether);
         uint256 staked = staking.getStakedAmount(user);
@@ -109,177 +106,213 @@ contract ThriveStakingERC20Test is Test {
         assertEq(staked, 2 ether);
     }
 
-    function testCalculateYield_FirstHalfStake() public {
+    function testCalculateYield_FirstHalfStake_SingleEpoch() public {
         vm.prank(user);
         mockToken.approve(address(staking), minStakingAmount);
-
         vm.prank(user);
         staking.stake(minStakingAmount);
-        uint256 staked = minStakingAmount;
         (, uint256 firstHalfTimestamp,,,) = staking.stakers(user);
-        uint256 currentEpoch = staking.currentEpoch();
-        uint256 epochEnd = staking.epochStart() + ((currentEpoch + 1) * 30 days);
-        vm.warp(epochEnd + 1);
-        uint256 expectedYield = (
-            staked * yieldRate * (epochEnd - firstHalfTimestamp)
-        ) / 10 ** mockToken.decimals();
-        (uint256 yieldCalculated,) = staking.calculateYield(user);
 
-        assertEq(yieldCalculated, expectedYield);
+        uint256 epochEnd = staking.epochStart() + EPOCH_DURATION;
+        vm.warp(epochEnd + 1);
+
+        uint256 timeStaked = epochEnd - firstHalfTimestamp;
+        uint256 expectedYield =
+            (minStakingAmount * yieldRate * timeStaked) / 1e18;
+
+        (uint256 claimableYield, uint256 ongoingYield) =
+            staking.calculateYield(user);
+        assertEq(
+            claimableYield,
+            expectedYield,
+            "Claimable yield should match expected"
+        );
     }
 
-    function testCalculateYield_SecondHalfStake() public {
-        uint256 currentEpoch = staking.currentEpoch();
-        uint256 epochPhaseStart =
-            staking.epochStart() + (currentEpoch * 30 days);
-        vm.warp(epochPhaseStart + 16 days);
+    function testCalculateYield_SecondHalfStake_SingleEpoch() public {
+        vm.warp(staking.epochStart() + HALF_EPOCH_DURATION + 1); // Second half
         vm.prank(user);
         mockToken.approve(address(staking), minStakingAmount);
-
         vm.prank(user);
         staking.stake(minStakingAmount);
         (,,, uint256 secondHalfTimestamp,) = staking.stakers(user);
-        uint256 staked = minStakingAmount;
 
-        vm.warp(block.timestamp + 4 days);
-        uint256 expectedYield = (
-            staked * yieldRate * (block.timestamp - secondHalfTimestamp)
-        ) / (2 * (10 ** mockToken.decimals()));
-        (, uint256 yieldOngoing) = staking.calculateYield(user);
+        uint256 epochEnd = staking.epochStart() + EPOCH_DURATION;
+        vm.warp(epochEnd + 1);
 
-        assertEq(yieldOngoing, expectedYield);
+        uint256 timeStaked = epochEnd - secondHalfTimestamp;
+        uint256 expectedYield =
+            (minStakingAmount * yieldRate * timeStaked) / (2 * 1e18);
+
+        (uint256 claimableYield, uint256 ongoingYield) =
+            staking.calculateYield(user);
+        assertEq(
+            claimableYield,
+            expectedYield,
+            "Claimable yield should match expected"
+        );
     }
 
-    function testClaimYieldRevertsIfNoStake() public {
+    function testCalculateYield_MultipleEpochs() public {
+        vm.prank(user);
+        mockToken.approve(address(staking), minStakingAmount);
+        vm.prank(user);
+        staking.stake(minStakingAmount);
+        (, uint256 firstHalfTimestamp,,,) = staking.stakers(user);
+
+        // Warp to start of Epoch 3 (90 days)
+        uint256 epoch3Start = staking.epochStart() + (3 * EPOCH_DURATION);
+        vm.warp(epoch3Start);
+
+        uint256 firstEpochTime =
+            staking.epochStart() + EPOCH_DURATION - firstHalfTimestamp;
+        uint256 firstEpochYield =
+            (minStakingAmount * yieldRate * firstEpochTime) / 1e18;
+        uint256 fullEpochYield =
+            (minStakingAmount * yieldRate * EPOCH_DURATION) / 1e18;
+        uint256 expectedYield = firstEpochYield + (2 * fullEpochYield); // 0.3 ETH total
+
+        (uint256 claimableYield, uint256 ongoingYield) =
+            staking.calculateYield(user);
+        assertEq(
+            claimableYield, expectedYield, "Claimable yield should be 0.3 ETH"
+        );
+        assertEq(ongoingYield, 0, "No ongoing yield at epoch start");
+    }
+
+    function testClaimYieldNoStake() public {
         vm.prank(user);
         vm.expectRevert("ThriveProtocol: no staked tokens");
         staking.claimYield();
     }
 
-    function testClaimYieldRevertsIfEpochNotFinished() public {
+    function testClaimYieldInsufficientFunds() public {
         vm.prank(user);
-        mockToken.approve(address(staking), 10 ether);
+        mockToken.approve(address(staking), minStakingAmount);
+        vm.prank(user);
+        staking.stake(minStakingAmount);
+
+        vm.warp(staking.epochStart() + EPOCH_DURATION + 1);
+        vm.deal(address(staking), 0); // No native funds for yield
 
         vm.prank(user);
-        staking.stake(10 ether);
-
-        vm.prank(user);
-        vm.expectRevert("ThriveProtocol: epoch not finished");
+        vm.expectRevert("Native yield transfer failed");
         staking.claimYield();
     }
 
     function testClaimYieldSuccess() public {
         vm.prank(user);
-        mockToken.approve(address(staking), 10 ether);
-        vm.prank(user);
-        staking.stake(10 ether);
-        uint256 initialEpoch = staking.currentEpoch();
-        uint256 epochEnd = staking.epochStart() + ((initialEpoch + 1) * 30 days);
-        vm.warp(epochEnd + 1);
-
-        (uint256 yieldCalculated,) = staking.calculateYield(user);
-
-        vm.prank(user);
-        vm.deal(address(staking), 10 ether);
-        staking.claimYield();
-
-        (uint256 yieldAfter,) = staking.calculateYield(user);
-        assertEq(yieldAfter, 0);
-
-        (uint256 firstHalf,, uint256 secondHalf,, uint256 newEpoch) =
-            staking.stakers(user);
-        uint256 totalStaked = firstHalf + secondHalf;
-        uint256 balanceAfter = address(user).balance;
-
-        assertEq(totalStaked, 10 ether);
-        assertEq(newEpoch, staking.currentEpoch());
-        assertEq(balanceAfter, yieldCalculated);
-    }
-
-    function testGetEpochEndTimestampRevertsForNoStake() public {
-        vm.prank(user);
-        vm.expectRevert("ThriveProtocol: no staked tokens");
-        staking.getEpochEndTimestamp(user);
-    }
-
-    function testGetEpochEndTimestampReturnsCorrectTimestamp() public {
-        vm.prank(user);
-        mockToken.approve(address(staking), 10 ether);
-        uint256 currentEpoch = staking.currentEpoch();
-        uint256 expectedEpochEnd =
-            staking.epochStart() + ((currentEpoch + 1) * 30 days);
-
+        mockToken.approve(address(staking), minStakingAmount);
         vm.prank(user);
         staking.stake(minStakingAmount);
-        uint256 epochEndTimestamp = staking.getEpochEndTimestamp(user);
 
-        assertEq(epochEndTimestamp, expectedEpochEnd);
-    }
-
-    function testWithdrawForfeitsYieldBeforeEpochEnd() public {
-        vm.prank(user);
-        mockToken.approve(address(staking), 10 ether);
-
-        vm.prank(user);
-        staking.stake(10 ether);
-
-        vm.prank(user);
+        uint256 epochEnd = staking.epochStart() + EPOCH_DURATION;
+        vm.warp(epochEnd + 1);
         vm.deal(address(staking), 10 ether);
-        staking.withdraw();
-        (,,,, uint256 epoch) = staking.stakers(user);
 
-        assertEq(epoch, 0);
+        (uint256 expectedYield,) = staking.calculateYield(user);
+        uint256 balanceBefore = user.balance;
+
+        vm.prank(user);
+        staking.claimYield();
+
+        assertEq(
+            user.balance,
+            balanceBefore + expectedYield,
+            "Balance should increase by yield"
+        );
+        assertEq(
+            staking.claimableYield(user), 0, "Claimable yield should reset"
+        );
+        (uint256 firstHalf,, uint256 secondHalf,, uint256 epoch) =
+            staking.stakers(user);
+        assertEq(firstHalf, minStakingAmount, "Stake should persist");
+        assertEq(secondHalf, 0, "Second half should be 0");
+        assertEq(epoch, 1, "Epoch should update to current");
     }
 
-    function testWithdrawSuccessWithYield() public {
+    function testYieldAcrossMultipleEpochs() public {
+        vm.prank(user);
+        mockToken.approve(address(staking), minStakingAmount);
+        vm.prank(user);
+        staking.stake(minStakingAmount);
+
+        // Warp to Epoch 3 start
+        uint256 epoch3Start = staking.epochStart() + (3 * EPOCH_DURATION);
+        vm.warp(epoch3Start);
+        vm.deal(address(staking), 10 ether);
+
+        (uint256 yieldBefore,) = staking.calculateYield(user);
+        assertGt(
+            yieldBefore, 0.29 ether, "Yield should be ~=0.3 ETH after 3 epochs"
+        );
+
+        vm.prank(user);
+        staking.claimYield();
+
+        assertEq(
+            staking.getStakedAmount(user), minStakingAmount, "Stake persists"
+        );
+        (uint256 yieldAfter,) = staking.calculateYield(user);
+        assertEq(yieldAfter, 0, "Claimable yield resets after claim");
+    }
+
+    function testWithdrawBeforeEpochEnds() public {
         vm.prank(user);
         mockToken.approve(address(staking), minStakingAmount);
         uint256 balanceBefore = mockToken.balanceOf(user);
 
         vm.prank(user);
         staking.stake(minStakingAmount);
-        uint256 staked = minStakingAmount;
-        uint256 initialEpoch = staking.currentEpoch();
-        uint256 epochEnd = staking.epochStart() + ((initialEpoch + 1) * 30 days);
-        vm.warp(epochEnd + 1);
+
+        vm.warp(block.timestamp + 10 days);
+        vm.prank(user);
+        staking.withdraw();
+
+        assertEq(
+            mockToken.balanceOf(user), balanceBefore, "Only principal returned"
+        );
+        assertEq(staking.getStakedAmount(user), 0, "Stake should be 0");
+        assertEq(staking.claimableYield(user), 0, "Claimable yield remains 0");
+    }
+
+    function testWithdrawMultipleEpochs() public {
+        vm.prank(user);
+        mockToken.approve(address(staking), minStakingAmount);
+        uint256 balanceBefore = mockToken.balanceOf(user);
 
         vm.prank(user);
+        staking.stake(minStakingAmount);
+
+        // Warp to Epoch 3 start
+        uint256 epoch3Start = staking.epochStart() + (3 * EPOCH_DURATION);
+        vm.warp(epoch3Start);
         vm.deal(address(staking), 10 ether);
+
+        (uint256 expectedYield,) = staking.calculateYield(user);
+        assertGt(expectedYield, 0.25 ether, "Yield should be ~=0.3 ETH");
+
+        vm.prank(user);
         staking.withdraw();
-        (
-            uint256 firstHalf,
-            uint256 firstHalfTimestamp,
-            uint256 secondHalf,
-            ,
-            uint256 epochAfter
-        ) = staking.stakers(user);
 
-        assertEq(firstHalf, 0);
-        assertEq(secondHalf, 0);
-        assertEq(epochAfter, 0);
-
-        uint256 balanceAfter = mockToken.balanceOf(user);
-        uint256 nativeBalanceAfterYield = address(user).balance;
-        uint256 expectedYield = (
-            staked * yieldRate * (epochEnd - firstHalfTimestamp)
-        ) / 10 ** mockToken.decimals();
-
-        assertEq(balanceAfter, balanceBefore);
-        assertEq(nativeBalanceAfterYield, expectedYield);
+        assertEq(mockToken.balanceOf(user), balanceBefore, "Principal returned");
+        assertEq(user.balance, expectedYield, "Yield paid in native");
+        assertEq(staking.getStakedAmount(user), 0, "Stake should be 0");
+        assertEq(staking.claimableYield(user), 0, "Claimable yield resets");
     }
 
     function testAdminFunctions() public {
-        uint256 newYield = 200;
+        uint256 newYield = 19_290_123_456;
         vm.prank(admin);
         staking.setYieldRate(newYield);
-
-        assertEq(staking.yieldRate(), newYield);
+        assertEq(staking.yieldRate(), newYield, "Yield rate not updated");
 
         uint256 newMin = 2 ether;
         vm.prank(admin);
         staking.setMinStakingAmount(newMin);
-
-        assertEq(staking.minStakingAmount(), newMin);
+        assertEq(
+            staking.minStakingAmount(), newMin, "Min staking amount not updated"
+        );
     }
 
     function testNonAdminCannotCallAdminFunctions() public {
@@ -292,37 +325,42 @@ contract ThriveStakingERC20Test is Test {
         staking.setMinStakingAmount(3 ether);
     }
 
-    function testStakeRevertsIfPendingYieldExists() public {
+    function testStakeAnytime() public {
+        vm.prank(user);
+        mockToken.approve(address(staking), 2 * minStakingAmount);
+
+        vm.prank(user);
+        staking.stake(minStakingAmount);
+
+        // Warp to Epoch 1 and stake again
+        vm.warp(staking.epochStart() + EPOCH_DURATION + 1);
+        vm.prank(user);
+        staking.stake(minStakingAmount);
+
+        assertEq(
+            staking.getStakedAmount(user),
+            2 ether,
+            "Total stake should be 2 ETH"
+        );
+    }
+
+    function testClaimableYieldStorageBeforeInteraction() public {
         vm.prank(user);
         mockToken.approve(address(staking), minStakingAmount);
         vm.prank(user);
         staking.stake(minStakingAmount);
-        uint256 initialEpoch = staking.currentEpoch();
-        vm.warp(staking.epochStart() + ((initialEpoch + 1) * 30 days) + 1);
-        vm.prank(user);
-        mockToken.approve(address(staking), minStakingAmount);
-        vm.prank(user);
-        vm.expectRevert("ThriveProtocol: finalize previous epoch first");
-        staking.stake(minStakingAmount);
-    }
 
-    function testSetAccessControlEnumerableRevertsForNonOwnerERC20() public {
-        vm.prank(user);
-        vm.expectRevert();
-        staking.setAccessControlEnumerable(address(0), bytes32("NEW_ROLE"));
-    }
-
-    function testSetAccessControlEnumerableSuccessERC20() public {
-        ThriveProtocolAccessControl newAccessControlImpl =
-            new ThriveProtocolAccessControl();
-        bytes memory data = abi.encodeCall(newAccessControlImpl.initialize, ());
-        address newProxy =
-            address(new ERC1967Proxy(address(newAccessControlImpl), data));
-        bytes32 newAdminRole = keccak256("NEW_ROLE");
-
-        staking.setAccessControlEnumerable(newProxy, newAdminRole);
-
-        assertEq(staking.adminRole(), newAdminRole);
-        assertEq(address(staking.accessControlEnumerable()), newProxy);
+        vm.warp(staking.epochStart() + (3 * EPOCH_DURATION));
+        assertEq(
+            staking.claimableYield(user),
+            0,
+            "Claimable yield in storage is 0 before interaction"
+        );
+        (uint256 totalClaimableYield,) = staking.calculateYield(user);
+        assertGt(
+            totalClaimableYield,
+            0.29 ether,
+            "Total claimable yield shows correctly"
+        );
     }
 }

--- a/test/ThriveStakingIERC20.t.sol
+++ b/test/ThriveStakingIERC20.t.sol
@@ -8,7 +8,7 @@ import {ERC1967Proxy} from
 import {ThriveProtocolAccessControl} from "src/ThriveProtocolAccessControl.sol";
 import {MockERC20} from "test/mock/MockERC20.sol";
 
-/// @dev Test suite for ERC20 token staking logic with automatic rollover.
+/// @dev Test suite for ERC20 token staking logic
 contract ThriveStakingERC20Test is Test {
     ThriveStakingIERC20 staking;
     MockERC20 public mockToken;
@@ -129,7 +129,7 @@ contract ThriveStakingERC20Test is Test {
     }
 
     function testCalculateYield_SecondHalfStake_SingleEpoch() public {
-        vm.warp(staking.epochStart() + HALF_EPOCH_DURATION + 1); // Second half
+        vm.warp(staking.epochStart() + HALF_EPOCH_DURATION + 1);
         vm.prank(user);
         mockToken.approve(address(staking), minStakingAmount);
         vm.prank(user);
@@ -158,7 +158,6 @@ contract ThriveStakingERC20Test is Test {
         staking.stake(minStakingAmount);
         (, uint256 firstHalfTimestamp,,,) = staking.stakers(user);
 
-        // Warp to start of Epoch 3 (90 days)
         uint256 epoch3Start = staking.epochStart() + (3 * EPOCH_DURATION);
         vm.warp(epoch3Start);
 
@@ -168,7 +167,7 @@ contract ThriveStakingERC20Test is Test {
             (minStakingAmount * yieldRate * firstEpochTime) / 1e18;
         uint256 fullEpochYield =
             (minStakingAmount * yieldRate * EPOCH_DURATION) / 1e18;
-        uint256 expectedYield = firstEpochYield + (2 * fullEpochYield); // 0.3 ETH total
+        uint256 expectedYield = firstEpochYield + (2 * fullEpochYield);
 
         (uint256 claimableYield, uint256 ongoingYield) =
             staking.calculateYield(user);
@@ -191,7 +190,7 @@ contract ThriveStakingERC20Test is Test {
         staking.stake(minStakingAmount);
 
         vm.warp(staking.epochStart() + EPOCH_DURATION + 1);
-        vm.deal(address(staking), 0); // No native funds for yield
+        vm.deal(address(staking), 0);
 
         vm.prank(user);
         vm.expectRevert("Native yield transfer failed");
@@ -235,7 +234,6 @@ contract ThriveStakingERC20Test is Test {
         vm.prank(user);
         staking.stake(minStakingAmount);
 
-        // Warp to Epoch 3 start
         uint256 epoch3Start = staking.epochStart() + (3 * EPOCH_DURATION);
         vm.warp(epoch3Start);
         vm.deal(address(staking), 10 ether);
@@ -282,7 +280,6 @@ contract ThriveStakingERC20Test is Test {
         vm.prank(user);
         staking.stake(minStakingAmount);
 
-        // Warp to Epoch 3 start
         uint256 epoch3Start = staking.epochStart() + (3 * EPOCH_DURATION);
         vm.warp(epoch3Start);
         vm.deal(address(staking), 10 ether);
@@ -330,7 +327,6 @@ contract ThriveStakingERC20Test is Test {
         vm.prank(user);
         staking.stake(minStakingAmount);
 
-        // Warp to Epoch 1 and stake again
         vm.warp(staking.epochStart() + EPOCH_DURATION + 1);
         vm.prank(user);
         staking.stake(minStakingAmount);

--- a/test/ThriveStakingNative.t.sol
+++ b/test/ThriveStakingNative.t.sol
@@ -7,7 +7,7 @@ import {ERC1967Proxy} from
     "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {ThriveProtocolAccessControl} from "src/ThriveProtocolAccessControl.sol";
 
-/// @dev Test suite for native token staking logic with automatic rollover.
+/// @dev Test suite for native token staking logic
 contract ThriveStakingNativeTest is Test {
     ThriveStakingNative staking;
     ThriveProtocolAccessControl public accessControl;
@@ -84,11 +84,9 @@ contract ThriveStakingNativeTest is Test {
     function testMultipleStakesInEpoch() public {
         vm.deal(user, 10 ether);
 
-        // First stake
         vm.prank(user);
         staking.stake{value: minStakingAmount}(minStakingAmount);
 
-        // Second stake in the same epoch
         vm.warp(block.timestamp + 5 days);
         vm.prank(user);
         staking.stake{value: minStakingAmount}(minStakingAmount);
@@ -117,7 +115,7 @@ contract ThriveStakingNativeTest is Test {
         (, uint256 firstHalfTimestamp,,,) = staking.stakers(user);
 
         uint256 epochEnd = staking.epochStart() + EPOCH_DURATION;
-        vm.warp(epochEnd + 1); // Warp to after first epoch ends
+        vm.warp(epochEnd + 1);
 
         uint256 timeStaked = epochEnd - firstHalfTimestamp;
         uint256 expectedYield =
@@ -130,11 +128,12 @@ contract ThriveStakingNativeTest is Test {
             expectedYield,
             "Claimable yield should match expected"
         );
+        assertGt(ongoingYield, 0, "ongoing yield should be calculated");
     }
 
     function testCalculateYield_SecondHalfStake_SingleEpoch() public {
         vm.deal(user, 10 ether);
-        vm.warp(staking.epochStart() + HALF_EPOCH_DURATION + 1); // Warp to second half
+        vm.warp(staking.epochStart() + HALF_EPOCH_DURATION + 1);
         vm.prank(user);
         staking.stake{value: minStakingAmount}(minStakingAmount);
         (,,, uint256 secondHalfTimestamp,) = staking.stakers(user);
@@ -146,8 +145,7 @@ contract ThriveStakingNativeTest is Test {
         uint256 expectedYield =
             (minStakingAmount * yieldRate * timeStaked) / (2 * 1e18);
 
-        (uint256 claimableYield, uint256 ongoingYield) =
-            staking.calculateYield(user);
+        (uint256 claimableYield,) = staking.calculateYield(user);
         assertEq(
             claimableYield,
             expectedYield,
@@ -161,18 +159,16 @@ contract ThriveStakingNativeTest is Test {
         staking.stake{value: minStakingAmount}(minStakingAmount);
         (, uint256 firstHalfTimestamp,,,) = staking.stakers(user);
 
-        // Warp to start of Epoch 3 (90 days)
         uint256 epoch3Start = staking.epochStart() + (3 * EPOCH_DURATION);
         vm.warp(epoch3Start);
 
-        // Expected yield: 0.1 ETH per epoch, 3 epochs completed
         uint256 firstEpochTime =
             staking.epochStart() + EPOCH_DURATION - firstHalfTimestamp;
         uint256 firstEpochYield =
             (minStakingAmount * yieldRate * firstEpochTime) / 1e18;
         uint256 fullEpochYield =
             (minStakingAmount * yieldRate * EPOCH_DURATION) / 1e18;
-        uint256 expectedYield = firstEpochYield + (2 * fullEpochYield); // 0.3 ETH total
+        uint256 expectedYield = firstEpochYield + (2 * fullEpochYield);
 
         (uint256 claimableYield, uint256 ongoingYield) =
             staking.calculateYield(user);
@@ -194,7 +190,7 @@ contract ThriveStakingNativeTest is Test {
         staking.stake{value: minStakingAmount}(minStakingAmount);
 
         vm.warp(staking.epochStart() + EPOCH_DURATION + 1);
-        vm.deal(address(staking), 0); // No funds in contract
+        vm.deal(address(staking), 0);
 
         vm.prank(user);
         vm.expectRevert("Native yield transfer failed");
@@ -236,7 +232,6 @@ contract ThriveStakingNativeTest is Test {
         vm.prank(user);
         staking.stake{value: minStakingAmount}(minStakingAmount);
 
-        // Warp to Epoch 3 start
         uint256 epoch3Start = staking.epochStart() + (3 * EPOCH_DURATION);
         vm.warp(epoch3Start);
         vm.deal(address(staking), 1_000 ether);
@@ -254,6 +249,32 @@ contract ThriveStakingNativeTest is Test {
         );
         (uint256 yieldAfter,) = staking.calculateYield(user);
         assertEq(yieldAfter, 0, "Claimable yield resets after claim");
+    }
+
+    function testYieldWithMixedStakes() public {
+        vm.deal(user, 10 ether);
+
+        vm.prank(user);
+        staking.stake{value: minStakingAmount}(minStakingAmount);
+
+        vm.warp(staking.epochStart() + HALF_EPOCH_DURATION);
+        vm.prank(user);
+        staking.stake{value: minStakingAmount}(minStakingAmount);
+
+        vm.warp(staking.epochStart() + EPOCH_DURATION + 1);
+        (uint256 claimableYield,) = staking.calculateYield(user);
+
+        uint256 firstYield =
+            (minStakingAmount * yieldRate * EPOCH_DURATION) / 1e18;
+        uint256 secondYield =
+            (minStakingAmount * yieldRate * HALF_EPOCH_DURATION) / (2 * 1e18);
+        uint256 expectedYield = firstYield + secondYield;
+
+        assertEq(
+            claimableYield,
+            expectedYield,
+            "Yield should match mixed stake calculation"
+        );
     }
 
     function testWithdrawBeforeEpochEnds() public {
@@ -276,12 +297,22 @@ contract ThriveStakingNativeTest is Test {
         assertEq(staking.claimableYield(user), 0, "Claimable yield remains 0");
     }
 
+    function testWithdrawNoContractFunds() public {
+        vm.deal(user, 10 ether);
+        vm.prank(user);
+        staking.stake{value: minStakingAmount}(minStakingAmount);
+        vm.warp(staking.epochStart() + EPOCH_DURATION + 1);
+        vm.deal(address(staking), 0);
+        vm.prank(user);
+        vm.expectRevert("Native staked amount transfer failed");
+        staking.withdraw();
+    }
+
     function testWithdrawMultipleEpochs() public {
         vm.deal(user, 10 ether);
         vm.prank(user);
         staking.stake{value: minStakingAmount}(minStakingAmount);
 
-        // Warp to Epoch 3 start
         uint256 epoch3Start = staking.epochStart() + (3 * EPOCH_DURATION);
         vm.warp(epoch3Start);
         vm.deal(address(staking), 1_000 ether);
@@ -300,6 +331,49 @@ contract ThriveStakingNativeTest is Test {
         );
         assertEq(staking.getStakedAmount(user), 0, "Stake should be 0");
         assertEq(staking.claimableYield(user), 0, "Claimable yield resets");
+    }
+
+    function testWithdrawMidEpochWithPartialYield() public {
+        vm.deal(user, 10 ether);
+        vm.prank(user);
+        staking.stake{value: minStakingAmount}(minStakingAmount);
+
+        vm.warp(staking.epochStart() + HALF_EPOCH_DURATION);
+        vm.deal(address(staking), 1_000 ether);
+
+        vm.warp(staking.epochStart() + EPOCH_DURATION);
+        (uint256 partialYield,) = staking.calculateYield(user);
+        assertGt(partialYield, 0, "Partial yield should accumulate");
+
+        uint256 balanceBefore = user.balance;
+        vm.prank(user);
+        staking.withdraw();
+
+        assertEq(
+            user.balance,
+            balanceBefore + minStakingAmount + partialYield,
+            "Should withdraw principal plus partial yield"
+        );
+        assertEq(staking.getStakedAmount(user), 0, "Stake should be 0");
+    }
+
+    function testWithdrawWithNoStake() public {
+        vm.prank(user);
+        vm.expectRevert("ThriveProtocol: no staked tokens");
+        staking.withdraw();
+    }
+
+    function testWithdrawInsufficientContractBalance() public {
+        vm.deal(user, 10 ether);
+        vm.prank(user);
+        staking.stake{value: minStakingAmount}(minStakingAmount);
+
+        vm.warp(staking.epochStart() + EPOCH_DURATION + 1);
+        vm.deal(address(staking), 0);
+
+        vm.prank(user);
+        vm.expectRevert("Native staked amount transfer failed");
+        staking.withdraw();
     }
 
     function testAdminFunctions() public {
@@ -331,7 +405,6 @@ contract ThriveStakingNativeTest is Test {
         vm.prank(user);
         staking.stake{value: minStakingAmount}(minStakingAmount);
 
-        // Warp to Epoch 1 and stake again
         vm.warp(staking.epochStart() + EPOCH_DURATION + 1);
         vm.prank(user);
         staking.stake{value: minStakingAmount}(minStakingAmount);
@@ -341,6 +414,83 @@ contract ThriveStakingNativeTest is Test {
             2 ether,
             "Total stake should be 2 ETH"
         );
+    }
+
+    function testStakeYieldSecondHalf() public {
+        vm.deal(user, 10 ether);
+        vm.prank(user);
+        staking.stake{value: minStakingAmount}(minStakingAmount);
+        vm.warp(staking.epochStart() + EPOCH_DURATION + HALF_EPOCH_DURATION + 1);
+        vm.deal(address(staking), 1 ether);
+        vm.prank(user);
+        staking.stakeYield();
+        (,, uint256 secondHalf,,) = staking.stakers(user);
+        assertGt(secondHalf, 0);
+    }
+
+    function testStakeAtEpochStart() public {
+        vm.deal(user, 10 ether);
+        vm.warp(staking.epochStart());
+        vm.prank(user);
+        staking.stake{value: minStakingAmount}(minStakingAmount);
+        (uint256 firstHalf, uint256 firstHalfTimestamp,,,) =
+            staking.stakers(user);
+        assertEq(firstHalf, minStakingAmount, "Stake should be in first half");
+        assertEq(
+            firstHalfTimestamp,
+            staking.epochStart(),
+            "Timestamp should match epoch start"
+        );
+    }
+
+    function testStakeJustBeforeEpochEnd() public {
+        vm.deal(user, 10 ether);
+        vm.warp(staking.epochStart() + EPOCH_DURATION - 1);
+
+        vm.prank(user);
+        staking.stake{value: minStakingAmount}(minStakingAmount);
+        (,, uint256 secondHalf, uint256 secondHalfTimestamp,) =
+            staking.stakers(user);
+
+        assertEq(secondHalf, minStakingAmount, "Stake should be in second half");
+        assertEq(
+            secondHalfTimestamp,
+            block.timestamp,
+            "Timestamp should match stake time"
+        );
+    }
+
+    function testStakeAtHalfEpochBoundary() public {
+        vm.deal(user, 10 ether);
+        vm.warp(staking.epochStart() + HALF_EPOCH_DURATION);
+
+        vm.prank(user);
+        staking.stake{value: minStakingAmount}(minStakingAmount);
+        (,, uint256 secondHalf,,) = staking.stakers(user);
+
+        assertEq(secondHalf, minStakingAmount);
+    }
+
+    function testStakeWithPendingYield() public {
+        vm.deal(user, 10 ether);
+        vm.prank(user);
+        staking.stake{value: minStakingAmount}(minStakingAmount);
+
+        vm.warp(staking.epochStart() + (2 * EPOCH_DURATION));
+        (uint256 pendingYield,) = staking.calculateYield(user);
+        assertGt(pendingYield, 0, "Should have pending yield");
+
+        vm.prank(user);
+        staking.stake{value: minStakingAmount}(minStakingAmount);
+        assertEq(
+            staking.getStakedAmount(user),
+            2 ether,
+            "Total stake should be 2 ETH"
+        );
+        (uint256 firstHalf,, uint256 secondHalf,,) = staking.stakers(user);
+
+        assertEq(firstHalf, 2 ether, "First half should accumulate both stakes");
+        assertEq(secondHalf, 0, "Second half should be 0");
     }
 
     function testClaimableYieldStorageBeforeInteraction() public {
@@ -360,5 +510,52 @@ contract ThriveStakingNativeTest is Test {
             0.25 ether,
             "Total claimable yield shows correctly"
         );
+    }
+
+    function testGetEpochEndTimestamp() public {
+        vm.deal(user, 10 ether);
+        vm.prank(user);
+        staking.stake{value: minStakingAmount}(minStakingAmount);
+        uint256 epochEnd = staking.getEpochEndTimestamp(user);
+
+        assertEq(
+            epochEnd,
+            staking.epochStart() + EPOCH_DURATION,
+            "Epoch end timestamp should match expected"
+        );
+    }
+
+    function testSetYieldRateToZero() public {
+        vm.prank(admin);
+        staking.setYieldRate(0);
+
+        assertEq(staking.yieldRate(), 0, "Yield rate should be 0");
+
+        vm.deal(user, 10 ether);
+        vm.prank(user);
+        staking.stake{value: minStakingAmount}(minStakingAmount);
+        vm.warp(staking.epochStart() + EPOCH_DURATION + 1);
+        (uint256 claimableYield,) = staking.calculateYield(user);
+
+        assertEq(claimableYield, 0, "Yield should be 0 with zero rate");
+    }
+
+    function testSetAccessControlEnumerableSuccess() public {
+        address newAccessControl = address(0x1234);
+        bytes32 newRole = keccak256("NEW_ROLE");
+        vm.prank(address(this));
+        staking.setAccessControlEnumerable(newAccessControl, newRole);
+
+        assertEq(address(staking.accessControlEnumerable()), newAccessControl);
+        assertEq(staking.adminRole(), newRole);
+    }
+
+    function testSetAccessControlEnumerableNonOwner() public {
+        address newAccessControl = address(0x1234);
+        bytes32 newRole = keccak256("NEW_ROLE");
+
+        vm.prank(admin);
+        vm.expectRevert();
+        staking.setAccessControlEnumerable(newAccessControl, newRole);
     }
 }

--- a/test/ThriveStakingNative.t.sol
+++ b/test/ThriveStakingNative.t.sol
@@ -7,13 +7,13 @@ import {ERC1967Proxy} from
     "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {ThriveProtocolAccessControl} from "src/ThriveProtocolAccessControl.sol";
 
-/// @dev Test suite for native token staking logic.
+/// @dev Test suite for native token staking logic with automatic rollover.
 contract ThriveStakingNativeTest is Test {
     ThriveStakingNative staking;
     ThriveProtocolAccessControl public accessControl;
     address admin = address(0xABCD);
     address user = address(0xBEEF);
-    uint256 yieldRate = 38580246913; // Per-second rate for 10% monthly yield
+    uint256 yieldRate = 38_580_246_913; // Per-second rate for 10% monthly yield (0.1 * 1e18 / 2,592,000)
     uint256 minStakingAmount = 1 ether;
     uint256 EPOCH_DURATION = 30 days;
     uint256 HALF_EPOCH_DURATION = 15 days;
@@ -110,93 +110,94 @@ contract ThriveStakingNativeTest is Test {
         assertEq(staked, 1 ether);
     }
 
-    function testCalculateYield_FirstHalfStake() public {
+    function testCalculateYield_FirstHalfStake_SingleEpoch() public {
         vm.deal(user, 10 ether);
         vm.prank(user);
         staking.stake{value: minStakingAmount}(minStakingAmount);
-        (
-            uint256 firstHalfAmount,
-            uint256 firstHalfTimestamp,
-            ,
-            ,
-            uint256 stakeEpoch
-        ) = staking.stakers(user);
+        (, uint256 firstHalfTimestamp,,,) = staking.stakers(user);
 
-        uint256 epochStart = staking.epochStart() + (stakeEpoch * 30 days);
-        uint256 epochEnd = epochStart + 30 days;
-        vm.warp(epochEnd + 1); // Warp to after epoch end
+        uint256 epochEnd = staking.epochStart() + EPOCH_DURATION;
+        vm.warp(epochEnd + 1); // Warp to after first epoch ends
 
-        uint256 effectiveTime = epochEnd; // Since block.timestamp > epochEnd, effectiveTime = epochEnd
-        uint256 timeStaked = effectiveTime - firstHalfTimestamp;
+        uint256 timeStaked = epochEnd - firstHalfTimestamp;
         uint256 expectedYield =
-            (firstHalfAmount * yieldRate * timeStaked) / 1e18;
+            (minStakingAmount * yieldRate * timeStaked) / 1e18;
 
         (uint256 claimableYield, uint256 ongoingYield) =
             staking.calculateYield(user);
-        assertEq(claimableYield, expectedYield);
-        assertEq(ongoingYield, 0); // Epoch has ended, so no ongoing yield
+        assertEq(
+            claimableYield,
+            expectedYield,
+            "Claimable yield should match expected"
+        );
     }
 
-    function testCalculateYield_SecondHalfStake() public {
+    function testCalculateYield_SecondHalfStake_SingleEpoch() public {
         vm.deal(user, 10 ether);
-        uint256 currentEpoch = staking.currentEpoch();
-        uint256 epochPhaseStart =
-            staking.epochStart() + (currentEpoch * 30 days);
-        vm.warp(epochPhaseStart + 16 days); // Warp to second half of the epoch
-
+        vm.warp(staking.epochStart() + HALF_EPOCH_DURATION + 1); // Warp to second half
         vm.prank(user);
         staking.stake{value: minStakingAmount}(minStakingAmount);
-        (
-            ,
-            ,
-            uint256 secondHalfAmount,
-            uint256 secondHalfTimestamp,
-            uint256 stakeEpoch
-        ) = staking.stakers(user);
+        (,,, uint256 secondHalfTimestamp,) = staking.stakers(user);
 
-        uint256 epochEnd = staking.epochStart() + ((stakeEpoch + 1) * 30 days);
-        vm.warp(epochEnd + 1); // Warp to after epoch end
+        uint256 epochEnd = staking.epochStart() + EPOCH_DURATION;
+        vm.warp(epochEnd + 1);
 
-        uint256 effectiveTime = epochEnd;
-        uint256 timeStaked = effectiveTime - secondHalfTimestamp;
+        uint256 timeStaked = epochEnd - secondHalfTimestamp;
         uint256 expectedYield =
-            (secondHalfAmount * yieldRate * timeStaked) / (2 * 1e18);
+            (minStakingAmount * yieldRate * timeStaked) / (2 * 1e18);
 
         (uint256 claimableYield, uint256 ongoingYield) =
             staking.calculateYield(user);
-        assertEq(claimableYield, expectedYield);
-        assertEq(ongoingYield, 0);
+        assertEq(
+            claimableYield,
+            expectedYield,
+            "Claimable yield should match expected"
+        );
     }
 
-    function testClaimYieldRevertsIfNoStake() public {
+    function testCalculateYield_MultipleEpochs() public {
+        vm.deal(user, 10 ether);
+        vm.prank(user);
+        staking.stake{value: minStakingAmount}(minStakingAmount);
+        (, uint256 firstHalfTimestamp,,,) = staking.stakers(user);
+
+        // Warp to start of Epoch 3 (90 days)
+        uint256 epoch3Start = staking.epochStart() + (3 * EPOCH_DURATION);
+        vm.warp(epoch3Start);
+
+        // Expected yield: 0.1 ETH per epoch, 3 epochs completed
+        uint256 firstEpochTime =
+            staking.epochStart() + EPOCH_DURATION - firstHalfTimestamp;
+        uint256 firstEpochYield =
+            (minStakingAmount * yieldRate * firstEpochTime) / 1e18;
+        uint256 fullEpochYield =
+            (minStakingAmount * yieldRate * EPOCH_DURATION) / 1e18;
+        uint256 expectedYield = firstEpochYield + (2 * fullEpochYield); // 0.3 ETH total
+
+        (uint256 claimableYield, uint256 ongoingYield) =
+            staking.calculateYield(user);
+        assertEq(
+            claimableYield, expectedYield, "Claimable yield should be 0.3 ETH"
+        );
+        assertEq(ongoingYield, 0, "No ongoing yield at epoch start");
+    }
+
+    function testClaimYieldNoStake() public {
         vm.prank(user);
         vm.expectRevert("ThriveProtocol: no staked tokens");
         staking.claimYield();
     }
 
-    function testClaimYieldFailsWithInsufficientFunds() public {
-        vm.deal(user, 10 ether);
-        vm.prank(user);
-        staking.stake{value: minStakingAmount}(minStakingAmount); // e.g., 1 ether
-
-        uint256 epochEnd = staking.epochStart() + 30 days;
-        vm.warp(epochEnd + 1);
-
-        vm.deal(address(staking), 0);
-        assertEq(address(staking).balance, 0, "Contract balance should be zero");
-
-        vm.prank(user);
-        vm.expectRevert("Native yield transfer failed");
-        staking.claimYield();
-    }
-
-    function testClaimYieldRevertsIfEpochNotFinished() public {
+    function testClaimYieldInsufficientFunds() public {
         vm.deal(user, 10 ether);
         vm.prank(user);
         staking.stake{value: minStakingAmount}(minStakingAmount);
 
+        vm.warp(staking.epochStart() + EPOCH_DURATION + 1);
+        vm.deal(address(staking), 0); // No funds in contract
+
         vm.prank(user);
-        vm.expectRevert("ThriveProtocol: epoch not finished");
+        vm.expectRevert("Native yield transfer failed");
         staking.claimYield();
     }
 
@@ -204,75 +205,55 @@ contract ThriveStakingNativeTest is Test {
         vm.deal(user, 10 ether);
         vm.prank(user);
         staking.stake{value: minStakingAmount}(minStakingAmount);
-        (,,,, uint256 stakeEpoch) = staking.stakers(user);
-        uint256 epochEnd = staking.epochStart() + ((stakeEpoch + 1) * 30 days);
 
+        uint256 epochEnd = staking.epochStart() + EPOCH_DURATION;
         vm.warp(epochEnd + 1);
         vm.deal(address(staking), 1_000 ether);
 
-        (uint256 claimableYield,) = staking.calculateYield(user);
-        assertGt(claimableYield, 0);
-
-        uint256 balanceBefore = address(user).balance;
+        (uint256 expectedYield,) = staking.calculateYield(user);
+        uint256 balanceBefore = user.balance;
 
         vm.prank(user);
         staking.claimYield();
 
-        (uint256 yieldAfter,) = staking.calculateYield(user);
-        assertEq(yieldAfter, 0); // Claimable yield should be reset
-
-        (uint256 firstHalf,, uint256 secondHalf,, uint256 newEpoch) =
+        assertEq(
+            user.balance,
+            balanceBefore + expectedYield,
+            "Balance should increase by yield"
+        );
+        assertEq(
+            staking.claimableYield(user), 0, "Claimable yield should reset"
+        );
+        (uint256 firstHalf,, uint256 secondHalf,, uint256 epoch) =
             staking.stakers(user);
-        uint256 totalStaked = firstHalf + secondHalf;
-        uint256 balanceAfter = address(user).balance;
-
-        assertEq(totalStaked, minStakingAmount);
-        assertEq(firstHalf, minStakingAmount);
-        assertEq(secondHalf, 0);
-        assertEq(newEpoch, staking.currentEpoch());
-        assertEq(balanceAfter, balanceBefore + claimableYield);
+        assertEq(firstHalf, minStakingAmount, "Stake should persist");
+        assertEq(secondHalf, 0, "Second half should be 0");
+        assertEq(epoch, 1, "Epoch should update to current");
     }
 
     function testYieldAcrossMultipleEpochs() public {
         vm.deal(user, 10 ether);
         vm.prank(user);
         staking.stake{value: minStakingAmount}(minStakingAmount);
-        (,,,, uint256 stakeEpoch) = staking.stakers(user);
 
-        uint256 epoch1End = staking.epochStart() + ((stakeEpoch + 1) * 30 days);
-        vm.warp(epoch1End + 1);
+        // Warp to Epoch 3 start
+        uint256 epoch3Start = staking.epochStart() + (3 * EPOCH_DURATION);
+        vm.warp(epoch3Start);
         vm.deal(address(staking), 1_000 ether);
 
-        (uint256 yield1,) = staking.calculateYield(user);
+        (uint256 yieldBefore,) = staking.calculateYield(user);
+        assertGt(
+            yieldBefore, 0.25 ether, "Yield should be ~=0.3 ETH after 3 epochs"
+        );
+
         vm.prank(user);
         staking.claimYield();
 
-        uint256 epoch2End = epoch1End + 30 days;
-        vm.warp(epoch2End + 1);
-        (uint256 yield2,) = staking.calculateYield(user);
-
-        assertGt(yield1, 0);
-        assertGt(yield2, 0);
-        assertEq(staking.getStakedAmount(user), minStakingAmount); // Stake persists
-    }
-
-    function testGetEpochEndTimestampRevertsForNoStake() public {
-        vm.prank(user);
-        vm.expectRevert("ThriveProtocol: no staked tokens");
-        staking.getEpochEndTimestamp(user);
-    }
-
-    function testGetEpochEndTimestampReturnsCorrectTimestamp() public {
-        vm.deal(user, 10 ether);
-        uint256 currentEpoch = staking.currentEpoch();
-        uint256 expectedEpochEnd =
-            staking.epochStart() + ((currentEpoch + 1) * 30 days);
-
-        vm.prank(user);
-        staking.stake{value: 1 ether}(1 ether);
-        uint256 epochEndTimestamp = staking.getEpochEndTimestamp(user);
-
-        assertEq(epochEndTimestamp, expectedEpochEnd);
+        assertEq(
+            staking.getStakedAmount(user), minStakingAmount, "Stake persists"
+        );
+        (uint256 yieldAfter,) = staking.calculateYield(user);
+        assertEq(yieldAfter, 0, "Claimable yield resets after claim");
     }
 
     function testWithdrawBeforeEpochEnds() public {
@@ -281,63 +262,44 @@ contract ThriveStakingNativeTest is Test {
         staking.stake{value: minStakingAmount}(minStakingAmount);
 
         vm.warp(block.timestamp + 10 days);
-        uint256 balanceBefore = address(user).balance;
+        uint256 balanceBefore = user.balance;
 
         vm.prank(user);
         staking.withdraw();
 
-        uint256 balanceAfter = address(user).balance;
-        assertEq(balanceAfter, balanceBefore + minStakingAmount);
-        assertEq(staking.getStakedAmount(user), 0);
+        assertEq(
+            user.balance,
+            balanceBefore + minStakingAmount,
+            "Only principal returned"
+        );
+        assertEq(staking.getStakedAmount(user), 0, "Stake should be 0");
+        assertEq(staking.claimableYield(user), 0, "Claimable yield remains 0");
     }
 
-    function testWithdrawForfeitsYieldBeforeEpochEnd() public {
+    function testWithdrawMultipleEpochs() public {
         vm.deal(user, 10 ether);
         vm.prank(user);
         staking.stake{value: minStakingAmount}(minStakingAmount);
 
-        vm.prank(user);
-        staking.withdraw();
-        (uint256 firstHalf,, uint256 secondHalf,, uint256 epoch) =
-            staking.stakers(user);
-
-        assertEq(firstHalf, 0);
-        assertEq(secondHalf, 0);
-        assertEq(epoch, 0);
-    }
-
-    function testWithdrawSuccessWithYield() public {
+        // Warp to Epoch 3 start
+        uint256 epoch3Start = staking.epochStart() + (3 * EPOCH_DURATION);
+        vm.warp(epoch3Start);
         vm.deal(address(staking), 1_000 ether);
-        vm.deal(user, 10 ether);
-        vm.prank(user);
-        staking.stake{value: minStakingAmount}(minStakingAmount);
-        (
-            uint256 firstHalfAmount,
-            uint256 firstHalfTimestamp,
-            ,
-            ,
-            uint256 stakeEpoch
-        ) = staking.stakers(user);
 
-        uint256 epochEnd = staking.epochStart() + ((stakeEpoch + 1) * 30 days);
-        vm.warp(epochEnd + 1);
+        (uint256 expectedYield,) = staking.calculateYield(user);
+        assertGt(expectedYield, 0.25 ether, "Yield should be ~=0.3 ETH");
 
-        uint256 balanceBefore = address(user).balance;
-        uint256 stakedAmount = staking.getStakedAmount(user);
-
-        uint256 effectiveTime = epochEnd;
-        uint256 timeStaked = effectiveTime - firstHalfTimestamp;
-        uint256 expectedYield =
-            (firstHalfAmount * yieldRate * timeStaked) / 1e18;
-
+        uint256 balanceBefore = user.balance;
         vm.prank(user);
         staking.withdraw();
 
-        (,,,, uint256 epochAfter) = staking.stakers(user);
-        assertEq(epochAfter, 0);
-
-        uint256 balanceAfter = address(user).balance;
-        assertEq(balanceAfter, balanceBefore + stakedAmount + expectedYield);
+        assertEq(
+            user.balance,
+            balanceBefore + minStakingAmount + expectedYield,
+            "Full withdrawal"
+        );
+        assertEq(staking.getStakedAmount(user), 0, "Stake should be 0");
+        assertEq(staking.claimableYield(user), 0, "Claimable yield resets");
     }
 
     function testAdminFunctions() public {
@@ -349,27 +311,9 @@ contract ThriveStakingNativeTest is Test {
         uint256 newMin = 2 ether;
         vm.prank(admin);
         staking.setMinStakingAmount(newMin);
-        assertEq(staking.minStakingAmount(), newMin);
-    }
-
-    function testYieldRateChangeMidEpoch() public {
-        vm.deal(user, 10 ether);
-        vm.prank(user);
-        staking.stake{value: minStakingAmount}(minStakingAmount);
-
-        vm.warp(block.timestamp + 15 days);
-        vm.prank(admin);
-        staking.setYieldRate(yieldRate * 2);
-
-        uint256 epochEnd = staking.epochStart() + 30 days;
-        vm.warp(epochEnd + 1);
-        vm.deal(address(staking), 1_000 ether);
-
-        (uint256 yield,) = staking.calculateYield(user);
-        vm.prank(user);
-        staking.claimYield();
-
-        assertGt(yield, 0);
+        assertEq(
+            staking.minStakingAmount(), newMin, "Min staking amount not updated"
+        );
     }
 
     function testNonAdminCannotCallAdminFunctions() public {
@@ -382,51 +326,39 @@ contract ThriveStakingNativeTest is Test {
         staking.setMinStakingAmount(3 ether);
     }
 
-    function testStakeRevertsIfPendingYieldExists() public {
+    function testStakeAnytime() public {
         vm.deal(user, 10 ether);
         vm.prank(user);
         staking.stake{value: minStakingAmount}(minStakingAmount);
-        uint256 initialEpoch = staking.currentEpoch();
-        vm.warp(staking.epochStart() + ((initialEpoch + 1) * 30 days) + 1);
-        vm.deal(user, 10 ether);
 
-        vm.prank(user);
-        vm.expectRevert("ThriveProtocol: finalize previous epoch first");
-        staking.stake{value: minStakingAmount}(minStakingAmount);
-    }
-
-    function testStakeAtEpochBoundary() public {
-        vm.deal(user, 10 ether);
-        uint256 epochEnd = staking.epochStart() + 30 days;
-        vm.warp(epochEnd);
-
+        // Warp to Epoch 1 and stake again
+        vm.warp(staking.epochStart() + EPOCH_DURATION + 1);
         vm.prank(user);
         staking.stake{value: minStakingAmount}(minStakingAmount);
 
-        vm.warp(epochEnd + 30 days + 1);
-        vm.deal(address(staking), 1_000 ether);
-
-        (uint256 yield,) = staking.calculateYield(user);
-        assertGt(yield, 0);
+        assertEq(
+            staking.getStakedAmount(user),
+            2 ether,
+            "Total stake should be 2 ETH"
+        );
     }
 
-    function testSetAccessControlEnumerableRevertsForNonOwnerNative() public {
+    function testClaimableYieldStorageBeforeInteraction() public {
+        vm.deal(user, 10 ether);
         vm.prank(user);
-        vm.expectRevert();
-        staking.setAccessControlEnumerable(address(0), bytes32("NEW_ROLE"));
-    }
+        staking.stake{value: minStakingAmount}(minStakingAmount);
 
-    function testSetAccessControlEnumerableSuccessNative() public {
-        ThriveProtocolAccessControl newAccessControlImpl =
-            new ThriveProtocolAccessControl();
-        bytes memory data = abi.encodeCall(newAccessControlImpl.initialize, ());
-        address newProxy =
-            address(new ERC1967Proxy(address(newAccessControlImpl), data));
-        bytes32 newAdminRole = keccak256("NEW_ROLE");
-
-        staking.setAccessControlEnumerable(newProxy, newAdminRole);
-
-        assertEq(staking.adminRole(), newAdminRole);
-        assertEq(address(staking.accessControlEnumerable()), newProxy);
+        vm.warp(staking.epochStart() + (3 * EPOCH_DURATION));
+        assertEq(
+            staking.claimableYield(user),
+            0,
+            "Claimable yield in storage is 0 before interaction"
+        );
+        (uint256 totalClaimableYield,) = staking.calculateYield(user);
+        assertGt(
+            totalClaimableYield,
+            0.25 ether,
+            "Total claimable yield shows correctly"
+        );
     }
 }

--- a/test/reviewer-protocol/unit-tests/ThriveReviewFactory.t.sol
+++ b/test/reviewer-protocol/unit-tests/ThriveReviewFactory.t.sol
@@ -88,7 +88,7 @@ contract ThriveReviewFactoryUnitTests is Test, BasicTestConfigs {
     function test03_revert_ToCreateContractsWithInsufficientFunds() public {
         // Test creating a ThriveWorkUnit and ThriveReview contract with insufficient funds
         vm.expectRevert(
-            "ThriveReviewFactory: Insufficient funds to allocate rewards for reviewers sent"
+            "ThriveReviewFactory: Insufficient funds for review and worker unit"
         );
         thriveReviewFactory.createWorkUnitAndReviewContract{
             value: REVIEW_CONTRACT_ALLOCATION - 1
@@ -110,7 +110,7 @@ contract ThriveReviewFactoryUnitTests is Test, BasicTestConfigs {
 
         // Test creating a ThriveWorkUnit and ThriveReview contract with insufficient funds
         vm.expectRevert(
-            "ThriveReviewFactory: Insufficient funds to allocate rewards for reviewers"
+            "ThriveReviewFactory: Insufficient funds for review and worker unit"
         );
         thriveReviewFactory.createWorkUnitAndReviewContract{
             value: REVIEW_CONTRACT_ALLOCATION


### PR DESCRIPTION
Updated staking logic for the yield part, now:

Staked Amount is always there generating yield, rolled over into new epochs until the user withdraws.
Claimable Yield will always be rolled over to new epoch meaning user don't have a restricted time to claim it.
Added another option for user to be able to stake the yield directly and not just claim it.