### PR TITLE
[THC-7368] Implement Payout Reward Logic

### DIFF
--- a/src/ThriveProtocolIERC20Reward.sol
+++ b/src/ThriveProtocolIERC20Reward.sol
@@ -32,6 +32,12 @@ contract ThriveProtocolIERC20Reward is OwnableUpgradeable, UUPSUpgradeable {
      */
     event Reward(address indexed recipient, uint256 amount, string reason);
     /**
+     * @dev Emitted when an admin sends a reward directly to a user.
+     */
+    event RewardTransferred(
+        address indexed recipient, uint256 amount, string reason
+    );
+    /**
      * @dev Emitted when a user withdraws tokens from the contract.
      */
     event Withdrawal(address indexed user, uint256 amount);
@@ -108,6 +114,73 @@ contract ThriveProtocolIERC20Reward is OwnableUpgradeable, UUPSUpgradeable {
         balanceOf[_msgSender()] -= _amount;
         token.safeTransfer(_msgSender(), _amount);
         emit Withdrawal(_msgSender(), _amount);
+    }
+
+    /**
+     * @notice Sends an ERC20 token reward directly to a recipient's address.
+     * @dev This function sends tokens immediately.
+     * @param _recipient The address of the recipient.
+     * @param _amount The amount of the reward to send.
+     * @param _reason The reason for the reward.
+     */
+    function payoutReward(
+        address _recipient,
+        uint256 _amount,
+        string calldata _reason
+    ) external onlyAdmin {
+        require(
+            _amount > 0,
+            "ThriveProtocol: Payout amount must be greater than zero"
+        );
+        require(
+            token.balanceOf(address(this)) >= _amount,
+            "ThriveProtocol: Insufficient token balance"
+        );
+
+        emit RewardTransferred(_recipient, _amount, _reason);
+
+        token.safeTransfer(_recipient, _amount);
+    }
+
+    /**
+     * @notice Sends ERC20 token rewards directly to multiple recipients.
+     * @dev This function sends tokens immediately.
+     * @param _recipients The addresses of the recipients.
+     * @param _amounts The amounts of the rewards to send.
+     * @param _reasons The reasons for the rewards.
+     */
+    function payoutRewardBulk(
+        address[] calldata _recipients,
+        uint256[] calldata _amounts,
+        string[] calldata _reasons
+    ) external onlyAdmin {
+        require(
+            _recipients.length == _amounts.length
+                && _recipients.length == _reasons.length,
+            "ThriveProtocol: Array lengths mismatch"
+        );
+
+        uint256 totalPayout;
+        for (uint256 i = 0; i < _amounts.length; i++) {
+            totalPayout += _amounts[i];
+        }
+
+        require(
+            token.balanceOf(address(this)) >= totalPayout,
+            "ThriveProtocol: Insufficient token balance for bulk payout"
+        );
+
+        for (uint256 i = 0; i < _recipients.length; i++) {
+            uint256 amount = _amounts[i];
+            address recipient = _recipients[i];
+            string calldata reason = _reasons[i];
+
+            if (amount > 0) {
+                emit RewardTransferred(recipient, amount, reason);
+
+                token.safeTransfer(recipient, amount);
+            }
+        }
     }
 
     /**

--- a/src/ThriveProtocolNativeReward.sol
+++ b/src/ThriveProtocolNativeReward.sol
@@ -27,6 +27,12 @@ contract ThriveProtocolNativeReward is OwnableUpgradeable, UUPSUpgradeable {
      */
     event Reward(address indexed recipient, uint256 amount, string reason);
     /**
+     * @dev Emitted when an admin sends a reward directly to a user.
+     */
+    event RewardTransferred(
+        address indexed recipient, uint256 amount, string reason
+    );
+    /**
      * @dev Emitted when a user withdraws tokens from the contract.
      */
     event Withdrawal(address indexed user, uint256 amount);
@@ -125,6 +131,70 @@ contract ThriveProtocolNativeReward is OwnableUpgradeable, UUPSUpgradeable {
     }
 
     /**
+     * @notice Sends a native token reward directly to a recipient's address.
+     * @dev This function sends funds immediately, unlike the `reward` function which credits a balance for withdrawal.
+     * The contract must have sufficient balance to cover the payout.
+     * @param _recipient The address of the recipient.
+     * @param _amount The amount of the reward to send.
+     * @param _reason The reason for the reward.
+     */
+    function payoutReward(
+        address payable _recipient,
+        uint256 _amount,
+        string calldata _reason
+    ) external onlyAdmin {
+        require(
+            address(this).balance >= _amount,
+            "ThriveProtocol: Insufficient contract balance"
+        );
+
+        emit RewardTransferred(_recipient, _amount, _reason);
+
+        _transferNative(_recipient, _amount);
+    }
+
+    /**
+     * @notice Sends native token rewards directly to multiple recipients in a single transaction.
+     * @dev This function sends funds immediately. The contract must have sufficient balance to cover the total payout.
+     * @param _recipients The addresses of the recipients.
+     * @param _amounts The amounts of the rewards to send.
+     * @param _reasons The reasons for the rewards.
+     */
+    function payoutRewardBulk(
+        address payable[] calldata _recipients,
+        uint256[] calldata _amounts,
+        string[] calldata _reasons
+    ) external onlyAdmin {
+        require(
+            _recipients.length == _amounts.length
+                && _recipients.length == _reasons.length,
+            "Array lengths mismatch"
+        );
+
+        uint256 totalPayout;
+        for (uint256 i = 0; i < _amounts.length; i++) {
+            totalPayout += _amounts[i];
+        }
+
+        require(
+            address(this).balance >= totalPayout,
+            "ThriveProtocol: Insufficient contract balance for bulk payout"
+        );
+
+        for (uint256 i = 0; i < _recipients.length; i++) {
+            uint256 amount = _amounts[i];
+            address payable recipient = _recipients[i];
+            string calldata reason = _reasons[i];
+
+            if (amount > 0) {
+                emit RewardTransferred(recipient, amount, reason);
+
+                _transferNative(recipient, amount);
+            }
+        }
+    }
+
+    /**
      * @dev Give rewards to multiple recipients in bulk.
      * @param _recipients The addresses of the recipients.
      * @param _amounts The amounts of the rewards.
@@ -218,6 +288,16 @@ contract ThriveProtocolNativeReward is OwnableUpgradeable, UUPSUpgradeable {
         );
         balanceOf[_recipient] -= _amount;
         emit RewardRemoved(_recipient, _amount, _reason);
+    }
+
+    function _transferNative(address user, uint256 amount) internal {
+        require(
+            amount > 0,
+            "ThriveProtocol: Payout amount must be greater than zero"
+        );
+
+        (bool success,) = user.call{value: amount}("");
+        require(success, "ThriveProtocol: Native reward transfer failed");
     }
 
     /**

--- a/test/ThriveProtocolIERC20Reward.t.sol
+++ b/test/ThriveProtocolIERC20Reward.t.sol
@@ -18,6 +18,9 @@ contract ThriveProtocolIERC20RewardTest is Test {
     MockERC20 public token;
 
     event Reward(address indexed recipient, uint256 amount, string reason);
+    event RewardTransferred(
+        address indexed recipient, uint256 amount, string reason
+    );
     event Withdrawal(address indexed user, uint256 amount);
     event RewardRemoved(
         address indexed recipient, uint256 amount, string reason
@@ -111,6 +114,136 @@ contract ThriveProtocolIERC20RewardTest is Test {
             )
         );
         reward.deposit(1 ether);
+        vm.stopPrank();
+    }
+
+    /**
+     *
+     * Tests for payoutReward (Single ERC20)
+     *
+     */
+    function test_payoutReward_Success() public {
+        uint256 payoutAmount = 0.5 ether;
+        string memory payoutReason = "test payout";
+        token.mint(address(reward), 1 ether);
+
+        uint256 initialRecipientBalance = token.balanceOf(USER_A_ADDRESS);
+        uint256 initialContractBalance = token.balanceOf(address(reward));
+
+        vm.startPrank(ADMIN_ADDRESS);
+        vm.expectEmit(true, true, true, true);
+        emit RewardTransferred(USER_A_ADDRESS, payoutAmount, payoutReason);
+        reward.payoutReward(USER_A_ADDRESS, payoutAmount, payoutReason);
+        vm.stopPrank();
+
+        assertEq(
+            token.balanceOf(USER_A_ADDRESS),
+            initialRecipientBalance + payoutAmount,
+            "Recipient should receive the tokens"
+        );
+        assertEq(
+            token.balanceOf(address(reward)),
+            initialContractBalance - payoutAmount,
+            "Contract token balance should decrease"
+        );
+    }
+
+    function test_payoutReward_RevertIf_NonAdmin() public {
+        token.mint(address(reward), 1 ether);
+
+        vm.startPrank(NON_ADMIN_ADDRESS);
+        vm.expectRevert();
+        reward.payoutReward(USER_A_ADDRESS, 0.5 ether, "fail");
+        vm.stopPrank();
+    }
+
+    function test_payoutReward_RevertIf_InsufficientTokenBalance() public {
+        token.mint(address(reward), 0.1 ether);
+
+        vm.startPrank(ADMIN_ADDRESS);
+        vm.expectRevert("ThriveProtocol: Insufficient token balance");
+        reward.payoutReward(USER_A_ADDRESS, 0.5 ether, "fail");
+        vm.stopPrank();
+    }
+
+    function test_payoutReward_RevertIf_AmountIsZero() public {
+        token.mint(address(reward), 1 ether);
+
+        vm.startPrank(ADMIN_ADDRESS);
+        vm.expectRevert(
+            "ThriveProtocol: Payout amount must be greater than zero"
+        );
+        reward.payoutReward(USER_A_ADDRESS, 0, "fail");
+        vm.stopPrank();
+    }
+
+    /**
+     *
+     * Tests for payoutRewardBulk (ERC20)
+     *
+     */
+    function test_payoutRewardBulk_Success() public {
+        uint256 totalPayout = amounts[0] + amounts[1];
+        token.mint(address(reward), 1 ether);
+
+        uint256 initialRecipientABalance = token.balanceOf(recipients[0]);
+        uint256 initialRecipientBBalance = token.balanceOf(recipients[1]);
+        uint256 initialContractBalance = token.balanceOf(address(reward));
+
+        vm.startPrank(ADMIN_ADDRESS);
+        vm.expectEmit(true, true, true, true);
+        emit RewardTransferred(recipients[0], amounts[0], reasons[0]);
+        vm.expectEmit(true, true, true, true);
+        emit RewardTransferred(recipients[1], amounts[1], reasons[1]);
+
+        reward.payoutRewardBulk(recipients, amounts, reasons);
+        vm.stopPrank();
+
+        assertEq(
+            token.balanceOf(recipients[0]),
+            initialRecipientABalance + amounts[0],
+            "Recipient A token balance mismatch"
+        );
+        assertEq(
+            token.balanceOf(recipients[1]),
+            initialRecipientBBalance + amounts[1],
+            "Recipient B token balance mismatch"
+        );
+        assertEq(
+            token.balanceOf(address(reward)),
+            initialContractBalance - totalPayout,
+            "Contract token balance mismatch"
+        );
+    }
+
+    function test_payoutRewardBulk_RevertIf_NonAdmin() public {
+        token.mint(address(reward), 1 ether);
+
+        vm.startPrank(NON_ADMIN_ADDRESS);
+        vm.expectRevert();
+        reward.payoutRewardBulk(recipients, amounts, reasons);
+        vm.stopPrank();
+    }
+
+    function test_payoutRewardBulk_RevertIf_InsufficientTokenBalance() public {
+        uint256 totalPayout = amounts[0] + amounts[1];
+        token.mint(address(reward), totalPayout - 1 wei);
+
+        vm.startPrank(ADMIN_ADDRESS);
+        vm.expectRevert(
+            "ThriveProtocol: Insufficient token balance for bulk payout"
+        );
+        reward.payoutRewardBulk(recipients, amounts, reasons);
+        vm.stopPrank();
+    }
+
+    function test_payoutRewardBulk_RevertIf_ArrayLengthsMismatch() public {
+        uint256[] memory mismatchedAmounts = new uint256[](1);
+        mismatchedAmounts[0] = 1 ether;
+
+        vm.startPrank(ADMIN_ADDRESS);
+        vm.expectRevert("ThriveProtocol: Array lengths mismatch");
+        reward.payoutRewardBulk(recipients, mismatchedAmounts, reasons);
         vm.stopPrank();
     }
 

--- a/test/ThriveProtocolNativeReward.t.sol
+++ b/test/ThriveProtocolNativeReward.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {Test, console2} from "forge-std/Test.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
 import {ThriveProtocolNativeReward} from "../src/ThriveProtocolNativeReward.sol";
 import {ERC1967Proxy} from
     "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
@@ -15,12 +16,16 @@ contract ThriveProtocolNativeRewardTest is Test {
     ThriveProtocolAccessControl public accessControl;
 
     event Reward(address indexed recipient, uint256 amount, string reason);
+    event RewardTransferred(
+        address indexed recipient, uint256 amount, string reason
+    );
     event Withdrawal(address indexed user, uint256 amount);
     event RewardRemoved(
         address indexed recipient, uint256 amount, string reason
     );
 
     address[] public recipients;
+    address payable[] public payableRecipients;
     uint256[] public amounts;
     string[] public reasons;
 
@@ -52,6 +57,7 @@ contract ThriveProtocolNativeRewardTest is Test {
         vm.stopPrank();
 
         recipients = [address(2), address(3)];
+        payableRecipients = [payable(address(2)), payable(address(3))];
         amounts = [0.001 ether, 0.1 ether];
         reasons = ["deposited", "test"];
     }
@@ -138,6 +144,136 @@ contract ThriveProtocolNativeRewardTest is Test {
         vm.prank(USER_A_ADDRESS);
         vm.expectRevert("ThriveProtocol: must have admin role");
         reward.rewardBulk(recipients, amounts, reasons);
+    }
+
+    /**
+     *
+     * Tests for payoutReward (Single)
+     *
+     */
+    function test_payoutReward_Success() public {
+        uint256 payoutAmount = 0.5 ether;
+        string memory payoutReason = "test payout";
+        vm.deal(address(reward), 1 ether);
+
+        uint256 initialRecipientBalance = USER_A_ADDRESS.balance;
+        uint256 initialContractBalance = address(reward).balance;
+
+        vm.startPrank(ADMIN_ADDRESS);
+        vm.expectEmit(true, true, true, true);
+        emit RewardTransferred(USER_A_ADDRESS, payoutAmount, payoutReason);
+        reward.payoutReward(payable(USER_A_ADDRESS), payoutAmount, payoutReason);
+        vm.stopPrank();
+
+        assertEq(
+            USER_A_ADDRESS.balance,
+            initialRecipientBalance + payoutAmount,
+            "Recipient should receive the funds"
+        );
+        assertEq(
+            address(reward).balance,
+            initialContractBalance - payoutAmount,
+            "Contract balance should decrease"
+        );
+    }
+
+    function test_payoutReward_RevertIf_NonAdmin() public {
+        vm.deal(address(reward), 1 ether);
+
+        vm.startPrank(NON_ADMIN_ADDRESS);
+        vm.expectRevert();
+        reward.payoutReward(payable(USER_A_ADDRESS), 0.5 ether, "fail");
+        vm.stopPrank();
+    }
+
+    function test_payoutReward_RevertIf_InsufficientBalance() public {
+        vm.deal(address(reward), 0.1 ether);
+
+        vm.startPrank(ADMIN_ADDRESS);
+        vm.expectRevert("ThriveProtocol: Insufficient contract balance");
+        reward.payoutReward(payable(USER_A_ADDRESS), 0.5 ether, "fail");
+        vm.stopPrank();
+    }
+
+    function test_payoutReward_RevertIf_AmountIsZero() public {
+        vm.deal(address(reward), 1 ether);
+
+        vm.startPrank(ADMIN_ADDRESS);
+        vm.expectRevert(
+            "ThriveProtocol: Payout amount must be greater than zero"
+        );
+        reward.payoutReward(payable(USER_A_ADDRESS), 0, "fail");
+        vm.stopPrank();
+    }
+
+    /**
+     *
+     * Tests for payoutRewardBulk
+     *
+     */
+    function test_payoutRewardBulk_Success() public {
+        uint256 totalPayout = amounts[0] + amounts[1];
+        vm.deal(address(reward), 1 ether);
+
+        uint256 initialRecipientABalance = payableRecipients[0].balance;
+        uint256 initialRecipientBBalance = payableRecipients[1].balance;
+        uint256 initialContractBalance = address(reward).balance;
+
+        vm.startPrank(ADMIN_ADDRESS);
+        vm.expectEmit(true, true, true, true);
+        emit RewardTransferred(payableRecipients[0], amounts[0], reasons[0]);
+        vm.expectEmit(true, true, true, true);
+        emit RewardTransferred(payableRecipients[1], amounts[1], reasons[1]);
+
+        reward.payoutRewardBulk(payableRecipients, amounts, reasons);
+        vm.stopPrank();
+
+        assertEq(
+            payableRecipients[0].balance,
+            initialRecipientABalance + amounts[0],
+            "Recipient A balance mismatch"
+        );
+        assertEq(
+            payableRecipients[1].balance,
+            initialRecipientBBalance + amounts[1],
+            "Recipient B balance mismatch"
+        );
+        assertEq(
+            address(reward).balance,
+            initialContractBalance - totalPayout,
+            "Contract balance mismatch"
+        );
+    }
+
+    function test_payoutRewardBulk_RevertIf_NonAdmin() public {
+        vm.deal(address(reward), 1 ether);
+
+        vm.startPrank(NON_ADMIN_ADDRESS);
+        vm.expectRevert();
+        reward.payoutRewardBulk(payableRecipients, amounts, reasons);
+        vm.stopPrank();
+    }
+
+    function test_payoutRewardBulk_RevertIf_InsufficientBalance() public {
+        uint256 totalPayout = amounts[0] + amounts[1];
+        vm.deal(address(reward), totalPayout - 1 wei);
+
+        vm.startPrank(ADMIN_ADDRESS);
+        vm.expectRevert(
+            "ThriveProtocol: Insufficient contract balance for bulk payout"
+        );
+        reward.payoutRewardBulk(payableRecipients, amounts, reasons);
+        vm.stopPrank();
+    }
+
+    function test_payoutRewardBulk_RevertIf_ArrayLengthsMismatch() public {
+        uint256[] memory mismatchedAmounts = new uint256[](1);
+        mismatchedAmounts[0] = 1 ether;
+
+        vm.startPrank(ADMIN_ADDRESS);
+        vm.expectRevert("Array lengths mismatch");
+        reward.payoutRewardBulk(payableRecipients, mismatchedAmounts, reasons);
+        vm.stopPrank();
     }
 
     // //////////////


### PR DESCRIPTION
In this PR the logic of transferring rewards directly is implemented. Modified Contracts:
- ThriveProtocolNativeReward --deployed--> https://thrive-testnet.cloud.blockscout.com/address/0xa4F9da6954905E930940dd42878CB76D687916B3?tab=read_write_proxy 
- ThriveProtocolERC20Reward --deployed--> https://thrive-testnet.cloud.blockscout.com/address/0x5616eA0ea8ACF49AD2a045264F14E1545993aaF5?tab=read_write_proxy